### PR TITLE
Fix and test case for href with unicode in it (Ruby 1.9.2).

### DIFF
--- a/lib/loofah/html5/scrub.rb
+++ b/lib/loofah/html5/scrub.rb
@@ -17,7 +17,7 @@ module Loofah
             attr_node.remove unless HashedWhiteList::ALLOWED_ATTRIBUTES[attr_name]
             if HashedWhiteList::ATTR_VAL_IS_URI[attr_name]
               # this block lifted nearly verbatim from HTML5 sanitization
-              val_unescaped = CGI.unescapeHTML(attr_node.value).gsub(/`|[\000-\040\177\s]+|\302[\200-\240]/,'').downcase
+              val_unescaped = CGI.unescapeHTML(attr_node.value).gsub(/`|[\u0000-\u0020\u007F]+|[\uC280-\uC2A0]/,'').downcase
               if val_unescaped =~ /^[a-z0-9][-+.a-z0-9]*:/ and HashedWhiteList::ALLOWED_PROTOCOLS[val_unescaped.split(':')[0]].nil?
                 attr_node.remove
               end

--- a/test/html5/test_sanitizer.rb
+++ b/test/html5/test_sanitizer.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 #  these tests taken from the HTML5 sanitization project and modified for use with Loofah
 #  see the original here: http://code.google.com/p/html5lib/source/browse/ruby/test/test_sanitizer.rb
@@ -9,6 +10,11 @@ require 'json'
 
 class Html5TestSanitizer < Test::Unit::TestCase
   include Loofah
+
+  def test_unicode_quote()
+
+    puts Loofah.scrub_fragment('<A HREF="I’m sorry."></A>', :prune)
+  end
 
   def sanitize_xhtml stream
     Loofah.fragment(stream).scrub!(:escape).to_xhtml


### PR DESCRIPTION
Fix issue with parsing UTF-8 encoded attributes. Problem encountered with some RSS feeds and feedzirra.

Encoding::CompatibilityError: incompatible encoding regexp match (ASCII-8BIT regexp with UTF-8 string)
loofah/lib/loofah/html5/scrub.rb:20:in `gsub'
loofah/lib/loofah/html5/scrub.rb:20:in`block in scrub_attributes'
loofah/lib/loofah/html5/scrub.rb:11:in `each'
loofah/lib/loofah/html5/scrub.rb:11:in`scrub_attributes'
loofah/lib/loofah/scrubber.rb:95:in `html5lib_sanitize'
loofah/lib/loofah/scrubbers.rb:98:in`scrub'
loofah/lib/loofah/scrubber.rb:108:in `traverse_conditionally_top_down'
loofah/lib/loofah/scrubber.rb:78:in`traverse'
loofah/lib/loofah/instance_methods.rb:46:in `scrub!'
loofah/lib/loofah/instance_methods.rb:54:in`block in scrub!'
.rvm/gems/ruby-1.9.2-p180/gems/nokogiri-1.4.4/lib/nokogiri/xml/node_set.rb:239:in `block in each'
.rvm/gems/ruby-1.9.2-p180/gems/nokogiri-1.4.4/lib/nokogiri/xml/node_set.rb:238:in`upto'
.rvm/gems/ruby-1.9.2-p180/gems/nokogiri-1.4.4/lib/nokogiri/xml/node_set.rb:238:in `each'
loofah/lib/loofah/instance_methods.rb:54:in`scrub!'
loofah/lib/loofah/instance_methods.rb:44:in `scrub!'
loofah/lib/loofah.rb:52:in`scrub_fragment'
loofah/test/html5/test_sanitizer.rb:16:in `test_unicode_quote'
.rvm/gems/ruby-1.9.2-p180/gems/mocha-0.9.12/lib/mocha/integration/mini_test/version_142_to_172.rb:27:in`run'
