### PR TITLE
Fix logic bug in CSS attribute scrubbing

### DIFF
--- a/lib/loofah/html5/scrub.rb
+++ b/lib/loofah/html5/scrub.rb
@@ -66,7 +66,7 @@ module Loofah
               clean << "#{prop}: #{val};"
             elsif %w[background border margin padding].include?(prop.split('-')[0])
               clean << "#{prop}: #{val};" unless val.split().any? do |keyword|
-                WhiteList::ALLOWED_CSS_KEYWORDS.include?(keyword) &&
+                WhiteList::ALLOWED_CSS_KEYWORDS.exclude?(keyword) &&
                   keyword !~ /^(#[0-9a-f]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|\d{0,2}\.?\d{0,2}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)$/
               end
             elsif WhiteList::ALLOWED_SVG_PROPERTIES.include?(prop)


### PR DESCRIPTION
We need to check if something is neither a valid keyword nor a valid parameter.
The old version excluded perfectly acceptable CSS like "border: 1px solid #ad9b5a;"
"solid" is a valid keyword, and does not match the color/size regular expression, so the css rule got excluded.
