### PR TITLE
Fix ruby 1.9 invalid encoding

### DIFF
--- a/lib/loofah/html5/scrub.rb
+++ b/lib/loofah/html5/scrub.rb
@@ -1,3 +1,5 @@
+#encoding: US-ASCII
+
 require 'cgi'
 
 module Loofah


### PR DESCRIPTION
Fix the error when running with -KU option, which is the case when using Textmate to run tests
