### PR TITLE
Gauntlet section is out of date with html5lib

### DIFF
--- a/lib/loofah/html5/scrub.rb
+++ b/lib/loofah/html5/scrub.rb
@@ -57,7 +57,7 @@ module Loofah
           style = style.to_s.gsub(/url\s*\(\s*[^\s)]+?\s*\)\s*/, ' ')
 
           # gauntlet
-          return '' unless style =~ /^([:,;#%.\sa-zA-Z0-9!]|\w-\w|\'[\s\w]+\'|\"[\s\w]+\"|\([\d,\s]+\))*$/
+          return '' unless style =~ /^([-:,;#%.\sa-zA-Z0-9!]|\w-\w|\'[\s\w]+\'|\"[\s\w]+\"|\([\d,\s]+\))*$/
           return '' unless style =~ /^\s*([-\w]+\s*:[^:;]*(;\s*|$))*$/
 
           clean = []


### PR DESCRIPTION
Gauntlet section is out of date with html5lib and doesn't allow for things like "letter-spacing:-0.03em;". 
See http://code.google.com/searchframe#NXg3toovv0g/ruby/lib/html5/sanitizer.rb&q=gauntlet%20package:html5lib%5C.googlecode%5C.com&l=176
