### PR TITLE
Removed the require for ActionView helpers.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -232,6 +232,7 @@ are the same thing as (and arguably semantically clearer than):
 Loofah has two "view helpers": Loofah::Helpers.sanitize and
 Loofah::Helpers.strip_tags, both of which are drop-in replacements for
 the Rails ActionView helpers of the same name.
+These are no longer required automatically. You must require `loofah/helpers`. 
 
 == Requirements
 

--- a/lib/loofah.rb
+++ b/lib/loofah.rb
@@ -17,8 +17,6 @@ require 'loofah/xml/document_fragment'
 require 'loofah/html/document'
 require 'loofah/html/document_fragment'
 
-require 'loofah/helpers'
-
 # == Strings and IO Objects as Input
 #
 # Loofah.document and Loofah.fragment accept any IO object in addition

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,6 +6,9 @@ require 'minitest/autorun'
 
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "loofah"))
 
+# require the ActionView helpers here, since they are no longer required automatically
+require File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "loofah", "helpers"))
+
 puts "=> testing with Nokogiri #{Nokogiri::VERSION_INFO.inspect}"
 
 class Loofah::TestCase < MiniTest::Spec


### PR DESCRIPTION
We're integrating Loofah into Rails and as such we don't want the automatic monkey patching of ActionViews sanitize helpers.

//cc @rafaelfranca
