### PR TITLE
Shorthand css properties

### DIFF
--- a/lib/loofah/html5/scrub.rb
+++ b/lib/loofah/html5/scrub.rb
@@ -66,7 +66,7 @@ module Loofah
             prop.downcase!
             if WhiteList::ALLOWED_CSS_PROPERTIES.include?(prop)
               clean << "#{prop}: #{val};"
-            elsif %w[background border margin padding].include?(prop.split('-')[0])
+            elsif WhiteList::SHORTHAND_CSS_PROPERTIES.include?(prop.split('-')[0])
               clean << "#{prop}: #{val};" unless val.split().any? do |keyword|
                 WhiteList::ALLOWED_CSS_KEYWORDS.include?(keyword) &&
                   keyword !~ /^(#[0-9a-f]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|\d{0,2}\.?\d{0,2}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)$/

--- a/lib/loofah/html5/whitelist.rb
+++ b/lib/loofah/html5/whitelist.rb
@@ -133,6 +133,8 @@ module Loofah
       purple red right solid silver teal top transparent underline white
       yellow]
 
+      SHORTHAND_CSS_PROPERTIES = Set.new %w[background border margin padding]
+      
       ACCEPTABLE_SVG_PROPERTIES = Set.new %w[fill fill-opacity fill-rule stroke
       stroke-width stroke-linecap stroke-linejoin stroke-opacity]
 
@@ -164,7 +166,7 @@ module Loofah
       # additional tags we should consider safe since we have libxml2 fixing up our documents.
       TAGS_SAFE_WITH_LIBXML2 = Set.new %w[html head body]
       ALLOWED_ELEMENTS_WITH_LIBXML2 = ALLOWED_ELEMENTS + TAGS_SAFE_WITH_LIBXML2
-    end      
+    end
 
     ::Loofah::MetaHelpers.add_downcased_set_members_to_all_set_constants ::Loofah::HTML5::WhiteList
   end


### PR DESCRIPTION
The Loofah-Rails integration continues. To gel better with ActionViews' WhiteListSanitizer shorthand_css_properties I've have abstracted and added a corresponding constant.

//@rafaelfranca
