### PR TITLE
Switched ^ to \A and $ to \z in sanitize_css.

### DIFF
--- a/lib/loofah/html5/scrub.rb
+++ b/lib/loofah/html5/scrub.rb
@@ -57,8 +57,8 @@ module Loofah
           style = style.to_s.gsub(/url\s*\(\s*[^\s)]+?\s*\)\s*/, ' ')
 
           # gauntlet
-          return '' unless style =~ /^([:,;#%.\sa-zA-Z0-9!]|\w-\w|\'[\s\w]+\'|\"[\s\w]+\"|\([\d,\s]+\))*$/
-          return '' unless style =~ /^\s*([-\w]+\s*:[^:;]*(;\s*|$))*$/
+          return '' unless style =~ /\A([:,;#%.\sa-zA-Z0-9!]|\w-\w|\'[\s\w]+\'|\"[\s\w]+\"|\([\d,\s]+\))*\z/
+          return '' unless style =~ /\A\s*([-\w]+\s*:[^:;]*(;\s*|$))*\z/
 
           clean = []
           style.scan(/([-\w]+)\s*:\s*([^:;]*)/) do |prop, val|
@@ -69,7 +69,7 @@ module Loofah
             elsif %w[background border margin padding].include?(prop.split('-')[0])
               clean << "#{prop}: #{val};" unless val.split().any? do |keyword|
                 WhiteList::ALLOWED_CSS_KEYWORDS.include?(keyword) &&
-                  keyword !~ /^(#[0-9a-f]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|\d{0,2}\.?\d{0,2}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)$/
+                  keyword !~ /\A(#[0-9a-f]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|\d{0,2}\.?\d{0,2}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)\z/
               end
             elsif WhiteList::ALLOWED_SVG_PROPERTIES.include?(prop)
               clean << "#{prop}: #{val};"


### PR DESCRIPTION
Making sure bad people can't sneak in a newline in their CSS.
See here for more info: http://guides.rubyonrails.org/security.html#regular-expressions.

//@rafaelfranca
