### PR TITLE
Make sure shorthand css property values in ALLOWED_CSS_KEYWORDS get marked as clean.

### DIFF
--- a/lib/loofah/html5/scrub.rb
+++ b/lib/loofah/html5/scrub.rb
@@ -68,7 +68,7 @@ module Loofah
               clean << "#{prop}: #{val};"
             elsif %w[background border margin padding].include?(prop.split('-')[0])
               clean << "#{prop}: #{val};" unless val.split().any? do |keyword|
-                WhiteList::ALLOWED_CSS_KEYWORDS.include?(keyword) &&
+                !WhiteList::ALLOWED_CSS_KEYWORDS.include?(keyword) &&
                   keyword !~ /^(#[0-9a-f]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|\d{0,2}\.?\d{0,2}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)$/
               end
             elsif WhiteList::ALLOWED_SVG_PROPERTIES.include?(prop)

--- a/test/assets/testdata_sanitizer_tests1.dat
+++ b/test/assets/testdata_sanitizer_tests1.dat
@@ -152,7 +152,7 @@
   {
     "name": "platypus",
     "input": "<a href=\"http://www.ragingplatypus.com/\" style=\"display:block; position:absolute; left:0; top:0; width:100%; height:100%; z-index:1; background-color:black; background-image:url(http://www.ragingplatypus.com/i/cam-full.jpg); background-x:center; background-y:center; background-repeat:repeat;\">never trust your upstream platypus</a>",
-    "output": "<a href='http://www.ragingplatypus.com/' style='display: block; width: 100%; height: 100%; background-color: black; background-repeat: repeat;'>never trust your upstream platypus</a>"
+    "output": "<a href='http://www.ragingplatypus.com/' style='display: block; width: 100%; height: 100%; background-color: black; background-x: center; background-y: center;'>never trust your upstream platypus</a>"
   },
 
   {
@@ -484,14 +484,14 @@
     "xhtml": "<div style='color: blue;'></div>",
     "rexml": "<div style='color: blue;'></div>"
   },
-  
+
   {
    "name": "attributes_with_embedded_quotes",
    "input": "<img src=doesntexist.jpg\"'onerror=\"alert(1) />",
    "output": "<img src='doesntexist.jpg%22'onerror=%22alert(1)'>",
    "rexml": "Ill-formed XHTML!"
   },
-  
+
   {
    "name": "attributes_with_embedded_quotes_II",
    "input": "<img src=notthere.jpg\"\"onerror=\"alert(2) />",


### PR DESCRIPTION
Example: a rule like `background-x: center` should be included in the sanitized output since `center`is in `ALLOWED_CSS_KEYWORDS`.

So for:

``` ruby
clean << "#{prop}: #{val};" unless val.split().any? do |keyword|
  WhiteList::ALLOWED_CSS_KEYWORDS.include?(keyword) &&
    keyword !~ /^(#[0-9a-f]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|\d{0,2}\.?\d{0,2}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)$/
end
```

The block should return false. However, it doesn't.

Likewise we expect a property like `background-repeat: repeat` to not be included, since `repeat` isn't in `ALLOWED_CSS_KEYWORDS`. The block should return true for this to happen. It doesn't.

//cc @rafaelfranca
