### PR TITLE
Removed RR deprecation warning by removing include RR::Adapters::TestUnit.

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,8 +9,6 @@ require File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "loofah"
 puts "=> testing with Nokogiri #{Nokogiri::VERSION_INFO.inspect}"
 
 class Loofah::TestCase < MiniTest::Spec
-  include RR::Adapters::TestUnit
-
   class << self
     alias_method :context, :describe
   end


### PR DESCRIPTION
There was a deprecation warning telling me to do this when I ran the tests. Consider it done.

//cc @rafaelfranca
