### PR TITLE
Add encoding arg to DocumentFragment#parse to mimic Nokogiri

### DIFF
--- a/lib/loofah/html/document_fragment.rb
+++ b/lib/loofah/html/document_fragment.rb
@@ -14,10 +14,13 @@ module Loofah
         #  constructor. Applications should use Loofah.fragment to
         #  parse a fragment.
         #
-        def parse tags
+        def parse tags, encoding = nil
           doc = Loofah::HTML::Document.new
-          doc.encoding = tags.encoding.name if tags.respond_to?(:encoding)
-          self.new(doc, tags)
+
+          encoding ||= tags.respond_to?(:encoding) ? tags.encoding.name : 'UTF-8'
+          doc.encoding = encoding
+
+          new(doc, tags)
         end
       end
 

--- a/test/integration/test_html.rb
+++ b/test/integration/test_html.rb
@@ -29,6 +29,13 @@ class IntegrationTestHtml < Loofah::TestCase
         assert_equal "\ntweedle\n\nbeetle\n", html.to_text
       end
     end
+
+    context 'with an `encoding` arg' do
+      it "sets the parent document's encoding to accordingly" do
+        html = Loofah.fragment "<style>foo</style><div>bar</div>", 'US-ASCII'
+        assert_equal 'US-ASCII', html.document.encoding
+      end
+    end
   end
 
   context "html document" do


### PR DESCRIPTION
According to [the comments on `Loofah.fragment`](https://github.com/flavorjones/loofah/blob/v1.2.1/lib/loofah.rb#L42), it accepts the same parameters as `Nokogiri::HTML::DocumentFragment.parse`.  I'm sure this was probably true at original time of writing but it is no longer true, due to the fact that `Nokogiri::HTML::DocumentFragment.parse` now accepts an `encoding` argument, which is used to set the encoding of the parent Document for the DocumentFragment (or defaults to `'UTF-8'` if nothing is fed in).  This pull adds that `encoding` argument to `Loofah::HTML::DocumentFragment`, and makes it mimic [the functionality of the `parse` method for `Loofah::HTML::DocumentFragment.parse`](https://github.com/sparklemotion/nokogiri/blob/v1.5.5/lib/nokogiri/html/document_fragment.rb#L8).
