### PR TITLE
Extract css attribute scrubbing to its own method.

### DIFF
--- a/lib/loofah/html5/scrub.rb
+++ b/lib/loofah/html5/scrub.rb
@@ -48,13 +48,17 @@ module Loofah
               next
             end
           end
-          if node.attributes['style']
-            node['style'] = scrub_css node.attributes['style']
-          end
+
+          scrub_css_attribute node
 
           node.attribute_nodes.each do |attr_node|
             node.remove_attribute(attr_node.name) if attr_node.value !~ /[^[:space:]]/
           end
+        end
+
+        def scrub_css_attribute node
+          style = node.attributes['style']
+          style.value = scrub_css(style.value) if style
         end
 
         #  lifted nearly verbatim from html5lib


### PR DESCRIPTION
Hi Mike.

We're still working on integrating Loofah with Rails.
We have a custom scrubber, that lets you add both tags and attributes to allow when sanitizing. If people have added the style attribute, we don't want `scrub_attributes` to scrub that.
So I've added a `scrub_css_attribute` method.

Here's where we're using it: https://github.com/rafaelfranca/rails-html-sanitizer/blob/master/lib/rails/html/scrubbers.rb#L105
