### PR TITLE
tests: load minitest before rr

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,8 +1,8 @@
 require 'rubygems'
-require 'rr'
 require 'minitest/unit'
 require 'minitest/spec'
 require 'minitest/autorun'
+require 'rr'
 
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "loofah"))
 


### PR DESCRIPTION
When running the tests via rake/hoe (for example, with the `rake test` command), Rake invokes ruby and loads minitest/autorun before invoking the any of the actual test suite files.

On the other hand, when running the tests outside of rake/hoe, the test suite's helper.rb loads the RR gem before loading minitest/autorun. This ordering causes the test suite to fail because it cannot recognize the "`mock()`" function from RR.

Switch the ordering so that minitest/autorun loads before rr. This allows the test suite to pass in both cases.

---

Below is an example of the test failure and success with this change:

When loading "rr" before "minitest/autorun":

```
$ bundle exec ruby -I"lib:test" test/integration/test_scrubbers.rb
=> testing with Nokogiri {"warnings"=>[], "nokogiri"=>"1.6.1", "ruby"=>{"version"=>"1.9.3", "platform"=>"x86_64-linux", "description"=>"ruby 1.9.3p327 (2012-11-10 revision 37606) [x86_64-linux]", "engine"=>"ruby"}, "libxml"=>{"binding"=>"extension", "source"=>"packaged", "libxml2_path"=>"/home/gitoriousci193/.gems/gems/nokogiri-1.6.1/ports/x86_64-redhat-linux/libxml2/2.8.0", "libxslt_path"=>"/home/gitoriousci193/.gems/gems/nokogiri-1.6.1/ports/x86_64-redhat-linux/libxslt/1.1.26", "compiled"=>"2.8.0", "loaded"=>"2.8.0"}}
Run options: --seed 62138

# Running tests:

......E.............E......

Finished tests in 0.032207s, 838.3355 tests/s, 2359.7592 assertions/s.

  1) Error:
test_0001_be_a_shortcut_for_parse_and_scrub(Document::#scrub_document):
NoMethodError: undefined method `mock' for #<#<Class:0x000000016c86c0>:0x00000001710010>
    test/integration/test_scrubbers.rb:92:in `block (3 levels) in <class:IntegrationTestScrubbers>'

  2) Error:
test_0001_be_a_shortcut_for_parse_and_scrub(DocumentFragment::#scrub_fragment):
NoMethodError: undefined method `mock' for #<#<Class:0x000000017269c8>:0x000000016ada78>
    test/integration/test_scrubbers.rb:270:in `block (3 levels) in <class:IntegrationTestScrubbers>'

27 tests, 76 assertions, 0 failures, 2 errors, 0 skips
```

Conversely, when loading "minitest/autorun" before "rr": 

```
bundle exec ruby -I"lib:test" test/integration/test_scrubbers.rb
=> testing with Nokogiri {"warnings"=>[], "nokogiri"=>"1.6.1", "ruby"=>{"version"=>"1.9.3", "platform"=>"x86_64-linux", "description"=>"ruby 1.9.3p327 (2012-11-10 revision 37606) [x86_64-linux]", "engine"=>"ruby"}, "libxml"=>{"binding"=>"extension", "source"=>"packaged", "libxml2_path"=>"/home/gitoriousci193/.gems/gems/nokogiri-1.6.1/ports/x86_64-redhat-linux/libxml2/2.8.0", "libxslt_path"=>"/home/gitoriousci193/.gems/gems/nokogiri-1.6.1/ports/x86_64-redhat-linux/libxslt/1.1.26", "compiled"=>"2.8.0", "loaded"=>"2.8.0"}}
Run options: --seed 2556

# Running tests:

...........................

Finished tests in 0.039150s, 689.6586 tests/s, 1941.2611 assertions/s.

27 tests, 76 assertions, 0 failures, 0 errors, 0 skips
```
