### PR TITLE
Allow multi-word data attributes

### DIFF
--- a/lib/loofah/html5/scrub.rb
+++ b/lib/loofah/html5/scrub.rb
@@ -23,7 +23,7 @@ module Loofah
                           attr_node.node_name
                         end
 
-            if attr_name =~ /\Adata-\w+\z/
+            if attr_name =~ /\Adata-[\w-]+\z/
               next
             end
 

--- a/test/html5/test_sanitizer.rb
+++ b/test/html5/test_sanitizer.rb
@@ -97,6 +97,13 @@ class Html5TestSanitizer < Loofah::TestCase
     check_sanitization(input, htmloutput, output, output)
   end
 
+  def test_should_allow_multi_word_data_attributes
+    input = "<p data-foo-bar-id='11'>foo <bad>bar</bad> baz</p>"
+    output = htmloutput = "<p data-foo-bar-id='11'>foo &lt;bad&gt;bar&lt;/bad&gt; baz</p>"
+
+    check_sanitization(input, htmloutput, output, output)
+  end
+
   ##
   ##  libxml2 downcases attributes, so this is moot.
   ##


### PR DESCRIPTION
This is an extension of #59. It's very common when using data attributes to have a multi-word name like `data-user-email` or `data-shop-id`. However, the regex added in #59 wasn't general enough to allow these multi-word attributes so they are being scrubbed by the default scrubbers whereas single-word names like `data-user` are being passed over.

Sidenote: I double-checked the spec and separating words with dashes is definitely the correct way to be doing this
http://www.w3.org/TR/2011/WD-html5-20110525/elements.html#embedding-custom-non-visible-data-with-the-data-attributes

@flavorjones cc @rafaelfranca