### PR TITLE
Negative value sanitisation support for shorthand css properties

### DIFF
--- a/lib/loofah/html5/scrub.rb
+++ b/lib/loofah/html5/scrub.rb
@@ -79,7 +79,7 @@ module Loofah
             elsif WhiteList::SHORTHAND_CSS_PROPERTIES.include?(prop.split('-')[0])
               clean << "#{prop}: #{val};" unless val.split().any? do |keyword|
                 !WhiteList::ALLOWED_CSS_KEYWORDS.include?(keyword) &&
-                  keyword !~ /\A(#[0-9a-f]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|\d{0,2}\.?\d{0,2}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)\z/
+                  keyword !~ /\A(#[0-9a-f]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|-?\d{0,2}\.?\d{0,2}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)\z/
               end
             elsif WhiteList::ALLOWED_SVG_PROPERTIES.include?(prop)
               clean << "#{prop}: #{val};"

--- a/lib/loofah/html5/scrub.rb
+++ b/lib/loofah/html5/scrub.rb
@@ -23,7 +23,7 @@ module Loofah
                           attr_node.node_name
                         end
 
-            if attr_name =~ /\Adata-\w+\z/
+            if attr_name =~ /\Adata-\S+\z/
               next
             end
 

--- a/test/html5/test_sanitizer.rb
+++ b/test/html5/test_sanitizer.rb
@@ -97,6 +97,14 @@ class Html5TestSanitizer < Loofah::TestCase
     check_sanitization(input, htmloutput, output, output)
   end
 
+  def test_should_allow_data_attributes_with_dash
+    input = "<p data-index-number='123456'>123456</p>"
+
+    output = "<p data-index-number='123456'>123456</p>"
+    check_sanitization(input, output, output, output)
+  end
+
+
   ##
   ##  libxml2 downcases attributes, so this is moot.
   ##

--- a/test/html5/test_sanitizer.rb
+++ b/test/html5/test_sanitizer.rb
@@ -220,6 +220,12 @@ class Html5TestSanitizer < Loofah::TestCase
     sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
     assert_match %r/-0.03em/, sane.inner_html
   end
+
+  def test_css_negative_value_sanitization_shorthand_css_properties
+    html = "<span style=\"margin-left:-0.05em;\">"
+    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    assert_match %r/-0.05em/, sane.inner_html
+  end
 end
 
 # <html5_license>


### PR DESCRIPTION
The negative values were not supported on shorthand css properties like margin etc. Added a test case for that and changed the regexp.