### PR TITLE
Travis: build on JRuby 9.1.5.0, 1.7.26 and Rubinius 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
-sudo: false
+sudo: required
 dist: trusty
-group: beta
+group: stable
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ matrix:
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"
     - rvm: jruby-1.7.26
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"
-    - rvm: rubinius-3
+    - rvm: rbx-3
   allow_failures:
     - rvm: jruby-1.7.26
     - rvm: jruby-9.1.5.0
-    - rvm: rubinius-3
+    - rvm: rbx-3

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,8 @@ matrix:
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"
     - rvm: jruby-1.7.26
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"
-    - rvm: rbx
-    - rvm: rbx-2
+    - rvm: rbx-3
   allow_failures:
     - rvm: jruby-1.7.26
     - rvm: jruby-9.1.5.0
-    - rvm: rbx-2
+    - rvm: rbx-3

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,14 @@ rvm:
   - 2.2.3
   - ruby-head
   - jruby-1.7.22
-  - jruby-9.0.1.0
+  - jruby-9.1.5.0
   - rbx-19mode
   - rbx-2
 
 matrix:
+  - rvm: jruby-9.1.5.0
+    env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"
   allow_failures:
     - rvm: jruby-1.7.22
-    - rvm: jruby-9.0.1.0
+    - rvm: jruby-9.1.5.0
     - rvm: rbx-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,10 @@ matrix:
     - rvm: jruby
     - rvm: jruby-9.1.5.0
     - rvm: rbx-3
+
+# https://github.com/jruby/jruby/wiki/FAQs#why-is-jruby-so-slow-to-install-via-rvm
+# https://docs.travis-ci.com/user/installing-dependencies#Installing-Packages-with-the-APT-Addon
+addons:
+  apt:
+    packages:
+    - haveged

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby-9.1.5.0
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"
-    - rvm: jruby
+    - rvm: jruby-1.7.26
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"
     - rvm: rbx-3
   allow_failures:
-    - rvm: jruby
+    - rvm: jruby-1.7.26
     - rvm: jruby-9.1.5.0
     - rvm: rbx-3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 sudo: false
+dist: trusty
+group: beta
 
 matrix:
   include:
@@ -13,8 +15,8 @@ matrix:
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"
     - rvm: jruby-1.7.26
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"
-    - rvm: rbx-3
+    - rvm: rubinius-3
   allow_failures:
     - rvm: jruby-1.7.26
     - rvm: jruby-9.1.5.0
-    - rvm: rbx-3
+    - rvm: rubinius-3

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ rvm:
   - rbx-2
 
 matrix:
-  - rvm: jruby-9.1.5.0
-    env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"
+  include:
+    - rvm: jruby-9.1.5.0
+      env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"
   allow_failures:
     - rvm: jruby-1.7.22
     - rvm: jruby-9.1.5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,21 @@
 language: ruby
-
 sudo: false
-
-rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.7
-  - 2.2.3
-  - ruby-head
-  - jruby-1.7.22
-  - jruby-9.1.5.0
-  - rbx-19mode
-  - rbx-2
 
 matrix:
   include:
+    - rvm: 1.9.3
+    - rvm: 2.0.0
+    - rvm: 2.1.10
+    - rvm: 2.2.5
+    - rvm: 2.3.1
+    - rvm: ruby-head
     - rvm: jruby-9.1.5.0
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"
+    - rvm: jruby-1.7.26
+      env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"
+    - rvm: rbx
+    - rvm: rbx-2
   allow_failures:
-    - rvm: jruby-1.7.22
+    - rvm: jruby-1.7.26
     - rvm: jruby-9.1.5.0
     - rvm: rbx-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 sudo: required
 dist: trusty
 group: stable
+cache: bundler
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 sudo: required
 dist: trusty
-group: stable
+group: beta
 cache: bundler
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby-9.1.5.0
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"
-    - rvm: jruby-1.7.26
+    - rvm: jruby
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"
     - rvm: rbx-3
   allow_failures:
-    - rvm: jruby-1.7.26
+    - rvm: jruby
     - rvm: jruby-9.1.5.0
     - rvm: rbx-3

--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,16 @@ source "https://rubygems.org/"
 gem "nokogiri", ">=1.5.9"
 gem "crass", "~>1.0.2"
 
-gem "rdoc", "~>4.0", :group => [:development, :test]
 gem "rake", ">=0.8", :group => [:development, :test]
 gem "minitest", "~>2.2", :group => [:development, :test]
 gem "rr", "~>1.1.0", :group => [:development, :test]
-gem "json", ">=0", :group => [:development, :test]
+if RUBY_VERSION > '2.4'
+  gem "json", ">= 2.0", :group => [:development, :test]
+  gem "rdoc", ">= 5.0.0.beta2", :group => [:development, :test]
+else
+  gem "json", ">=0", :group => [:development, :test]
+  gem "rdoc", "~>4.0", :group => [:development, :test]
+end
 gem "hoe-gemspec", ">=0", :group => [:development, :test]
 gem "hoe-debugging", ">=0", :group => [:development, :test]
 gem "hoe-bundler", ">=0", :group => [:development, :test]


### PR DESCRIPTION
This PR changes the Travis setup to test on latest stable JRuby (9.1.5.0 and 1.7.26) and also on a recent Rubinius (rubinius 3.65 (2.3.1)).

- `rbx-19mode` never ran in the given configuration. It was not installed on the target build machine. Now the Travis config uses `rbx-3`. [Rubinius Travis Canary Build](https://travis-ci.org/rubinius/travis-canary) shows that `rbx-3` is there, so switched to that.
  - To get a working installation of Rubinius available, I had to select another build server target (Ubuntu 14.04).
- `ruby-head` uses json gem 2.0 and rdoc 5.0.0.beta2 to make it through installation
  - (I don't know Hoe, and how to add such a version-picking conditional in the Gemfile with that.)
- Travis' gce worker nodes needs an entropy-adding Debian package `haveged` to be able to install JRuby quick enough