### PR TITLE
Spec: avoid warning in test output

### DIFF
--- a/test/integration/test_helpers.rb
+++ b/test/integration/test_helpers.rb
@@ -37,7 +37,7 @@ class IntegrationTestHelpers < Loofah::TestCase
 
   context ".sanitize_css" do
     it "removes unsafe css properties" do
-      assert_match /display:\s*block;\s*background-color:\s*blue;/, Loofah::Helpers.sanitize_css("display:block;background-image:url(http://www.ragingplatypus.com/i/cam-full.jpg);background-color:blue")
+      assert_match(/display:\s*block;\s*background-color:\s*blue;/, Loofah::Helpers.sanitize_css("display:block;background-image:url(http://www.ragingplatypus.com/i/cam-full.jpg);background-color:blue"))
     end
   end
 end


### PR DESCRIPTION
This PR avoids a warning in test output, by adding parentheses.

> /home/travis/build/flavorjones/loofah/test/integration/test_helpers.rb:40: warning: Ambiguous first argument; make sure.
