### PR TITLE
Travis: use ruby-build release numbers; JRuby 9.1.7.0; use Bundler 1.14.pre.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: bundler
 
 before_install:
   - gem update --system
-  - gem install bundler --pre
+  - gem install bundler --pre # Bundler 1.14 will respect required_ruby_version in gemspec files
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,17 @@ matrix:
     - rvm: 1.9.3
     - rvm: 2.0.0
     - rvm: 2.1.10
-    - rvm: 2.2.5
-    - rvm: 2.3.1
+    - rvm: 2.2.6
+    - rvm: 2.3.3
     - rvm: ruby-head
-    - rvm: jruby-9.1.5.0
+    - rvm: jruby-9.1.7.0
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"
     - rvm: jruby-1.7.26
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"
     - rvm: rbx-3
   allow_failures:
     - rvm: jruby-1.7.26
-    - rvm: jruby-9.1.5.0
+    - rvm: jruby-9.1.7.0
     - rvm: rbx-3
 
 # https://github.com/jruby/jruby/wiki/FAQs#why-is-jruby-so-slow-to-install-via-rvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ dist: trusty
 group: beta
 cache: bundler
 
+before_install:
+  - gem update --system
+  - gem install bundler --pre
+
 matrix:
   include:
     - rvm: 1.9.3


### PR DESCRIPTION
This PR updates the JRuby version to 9.1.7.0 which is currently latest stable.

Also: Uses version numbers from [the ruby-build repository's shared definitions](https://github.com/rbenv/ruby-build/tree/master/share/ruby-build).

---


~~Should we make Gemfiles aware of this issue, or should we try to use Bundler 1.14.0.pre.2 which perhaps can know which Ruby can use which version of gems?~~

**Update:** Using Bundler 1.14.pre.2 _fixes_ the build for older rubies by respecting `required_ruby_version` in gemspecs. 🎉 https://github.com/bundler/bundler/pull/4650 was the Bundler fix that fixed it.

Example error for 2.0.0 when using Bundler < 1.14:

```
nokogiri-1.7.0.1 requires ruby version >= 2.1.0, which is incompatible with the
current version, ruby 2.0.0p648
```