### PR TITLE
Use rr-1.2 as a development dependency.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "crass", "~>1.0.2"
 
 gem "rake", ">=0.8", :group => [:development, :test]
 gem "minitest", "~>2.2", :group => [:development, :test]
-gem "rr", "~>1.1.0", :group => [:development, :test]
+gem "rr", "~>1.2.0", :group => [:development, :test]
 if RUBY_VERSION > '2.4'
   gem "json", ">= 2.0", :group => [:development, :test]
   gem "rdoc", ">= 5.0.0.beta2", :group => [:development, :test]

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ Hoe.spec "loofah" do
 
   extra_dev_deps << ["rake", ">=0.8"]
   extra_dev_deps << ["minitest", "~>2.2"]
-  extra_dev_deps << ["rr", "~>1.1.0"]
+  extra_dev_deps << ["rr", "~>1.2.0"]
   extra_dev_deps << ["json", ">=0"]
   extra_dev_deps << ["hoe-gemspec", ">=0"]
   extra_dev_deps << ["hoe-debugging", ">=0"]


### PR DESCRIPTION
Hi,
I want to use `rr` latest version 1.2.0.
https://rubygems.org/gems/rr

I did not include updated `loofah.gemspec` in this PR. because you might update it by yourself.
I succeeded unit tests with updated `loofah.gemspec`.

```
$ ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]

$ bundle -v
Bundler version 1.14.3

$ bundle install --path vendor/bundle

$ bundle exec rake gemspec

$ rm -rf vendor/ .bundle/ Gemfile.lock

$ bundle install --path vendor/bundle

$ bundle list
Gems included by the bundle:
  * bundler (1.14.3)
  * crass (1.0.2)
  * hoe (3.16.0)
  * hoe-bundler (1.3.0)
  * hoe-debugging (1.3.0)
  * hoe-gemspec (1.0.0)
  * hoe-git (1.6.0)
  * json (2.0.3)
  * mini_portile2 (2.1.0)
  * minitest (2.12.1)
  * nokogiri (1.7.0.1)
  * rake (12.0.0)
  * rdoc (5.0.0)
  * rr (1.2.0)

$ bundle exec rake test
...
822 tests, 941 assertions, 0 failures, 0 errors, 2 skips
```
