### PR TITLE
Allow select URI Data Mediatypes

### DIFF
--- a/lib/loofah/html5/scrub.rb
+++ b/lib/loofah/html5/scrub.rb
@@ -41,6 +41,14 @@ module Loofah
               if val_unescaped =~ /^[a-z0-9][-+.a-z0-9]*:/ && ! WhiteList::ALLOWED_PROTOCOLS.include?(val_unescaped.split(WhiteList::PROTOCOL_SEPARATOR)[0])
                 attr_node.remove
                 next
+              elsif val_unescaped.split(WhiteList::PROTOCOL_SEPARATOR)[0] == 'data'
+                # permit only allowed data mediatypes
+                mediatype = val_unescaped.split(WhiteList::PROTOCOL_SEPARATOR)[1]
+                mediatype, base64 = mediatype.split(';')[0..1] if mediatype
+                if mediatype && !WhiteList::ALLOWED_URI_DATA_MEDIATYPES.include?(mediatype)
+                  attr_node.remove
+                  next
+                end
               end
             end
             if WhiteList::SVG_ATTR_VAL_ALLOWS_REF.include?(attr_name)

--- a/lib/loofah/html5/whitelist.rb
+++ b/lib/loofah/html5/whitelist.rb
@@ -145,7 +145,10 @@ module Loofah
       PROTOCOL_SEPARATOR = /:|(&#0*58)|(&#x70)|(&#x0*3a)|(%|&#37;)3A/i
 
       ACCEPTABLE_PROTOCOLS = Set.new %w[ed2k ftp http https irc mailto news gopher nntp
-      telnet webcal xmpp callto feed urn aim rsync tag ssh sftp rtsp afs]
+      telnet webcal xmpp callto feed urn aim rsync tag ssh sftp rtsp afs data]
+
+      ACCEPTABLE_URI_DATA_MEDIATYPES = Set.new %w[text/plain text/css image/png image/gif
+        image/jpeg image/svg+xml]
 
       # subclasses may define their own versions of these constants
       ALLOWED_ELEMENTS = ACCEPTABLE_ELEMENTS + MATHML_ELEMENTS + SVG_ELEMENTS
@@ -154,6 +157,7 @@ module Loofah
       ALLOWED_CSS_KEYWORDS = ACCEPTABLE_CSS_KEYWORDS
       ALLOWED_SVG_PROPERTIES = ACCEPTABLE_SVG_PROPERTIES
       ALLOWED_PROTOCOLS = ACCEPTABLE_PROTOCOLS
+      ALLOWED_URI_DATA_MEDIATYPES = ACCEPTABLE_URI_DATA_MEDIATYPES
 
       VOID_ELEMENTS = Set.new %w[
         base

--- a/test/html5/test_sanitizer.rb
+++ b/test/html5/test_sanitizer.rb
@@ -136,6 +136,23 @@ class Html5TestSanitizer < Loofah::TestCase
       check_sanitization(input, output, output, output)
     end
   end
+  
+  HTML5::WhiteList::ALLOWED_URI_DATA_MEDIATYPES.each do |data_uri_type|
+    define_method "test_should_allow_data_#{data_uri_type}_uris" do
+      input = %(<a href="data:#{data_uri_type}">foo</a>)
+      output = "<a href='data:#{data_uri_type}'>foo</a>"
+      check_sanitization(input, output, output, output)
+    end
+  end
+
+  HTML5::WhiteList::ALLOWED_URI_DATA_MEDIATYPES.each do |data_uri_type|
+    define_method "test_should_allow_uppercase_data_#{data_uri_type}_uris" do
+      input = %(<a href="DATA:#{data_uri_type.upcase}">foo</a>)
+      output = "<a href='DATA:#{data_uri_type.upcase}'>foo</a>"
+      check_sanitization(input, output, output, output)
+    end
+  end
+
 
   HTML5::WhiteList::SVG_ALLOW_LOCAL_HREF.each do |tag_name|
     next unless HTML5::WhiteList::ALLOWED_ELEMENTS.include?(tag_name)


### PR DESCRIPTION
How is this for a start at resolving issue #101 ?

- Allows data as a protocol but then applies a filter on allowed mediatypes
- Is not checking/validating the optional `;base64` part of `data:<mediatype>[;base64],<data>`
- Is not checking/validating the data/data encoding
