### PR TITLE
Fix "warning: assigned but unused variable - base64"

### DIFF
--- a/lib/loofah/html5/scrub.rb
+++ b/lib/loofah/html5/scrub.rb
@@ -44,7 +44,7 @@ module Loofah
               elsif val_unescaped.split(WhiteList::PROTOCOL_SEPARATOR)[0] == 'data'
                 # permit only allowed data mediatypes
                 mediatype = val_unescaped.split(WhiteList::PROTOCOL_SEPARATOR)[1]
-                mediatype, base64 = mediatype.split(';')[0..1] if mediatype
+                mediatype, _ = mediatype.split(';')[0..1] if mediatype
                 if mediatype && !WhiteList::ALLOWED_URI_DATA_MEDIATYPES.include?(mediatype)
                   attr_node.remove
                   next


### PR DESCRIPTION
This fixes following warning:

```
vendor/bundle/ruby/2.4.0/gems/loofah-2.1.0/lib/loofah/html5/scrub.rb:47: warning: assigned but unused variable - base64
```