### PR TITLE
Provides workaround for nested scripts

### DIFF
--- a/lib/loofah.rb
+++ b/lib/loofah.rb
@@ -47,11 +47,18 @@ module Loofah
       Loofah.fragment(string_or_io).scrub!(method)
     end
 
+    def recursive_scrub_fragment(string_or_io, method, times = 3)
+      Loofah.fragment(string_or_io).scrub!(method, times, true)
+    end
+
     # Shortcut for Loofah.document(string_or_io).scrub!(method)
     def scrub_document(string_or_io, method)
       Loofah.document(string_or_io).scrub!(method)
     end
 
+    def recursive_scrub_document(string_or_io, method, times = 3)
+      Loofah.document(string_or_io).scrub!(method, times, true)
+    end
     # Shortcut for Loofah::XML::Document.parse
     # This method accepts the same parameters as Nokogiri::XML::Document.parse
     def xml_document(*args, &block)

--- a/lib/loofah/html/document.rb
+++ b/lib/loofah/html/document.rb
@@ -9,6 +9,7 @@ module Loofah
       include Loofah::ScrubBehavior::Node
       include Loofah::DocumentDecorator
       include Loofah::TextBehavior
+      include Loofah::StateRestore
 
       def serialize_root
         at_xpath("/html/body")

--- a/lib/loofah/html/document_fragment.rb
+++ b/lib/loofah/html/document_fragment.rb
@@ -7,6 +7,8 @@ module Loofah
     #
     class DocumentFragment < Nokogiri::HTML::DocumentFragment
       include Loofah::TextBehavior
+      include Loofah::StateRestore
+
 
       class << self
         #
@@ -24,12 +26,10 @@ module Loofah
         end
       end
 
-      #
-      #  Returns the HTML markup contained by the fragment
-      #
       def to_s
         serialize_root.children.to_s
       end
+
       alias :serialize :to_s
 
       def serialize_root

--- a/test/integration/test_ad_hoc.rb
+++ b/test/integration/test_ad_hoc.rb
@@ -16,6 +16,26 @@ class IntegrationTestAdHoc < Loofah::TestCase
     end
   end
 
+  def test_removal_of_a_nested_type1_illegal_tag
+    html = <<-HTML
+      following this there should be no jim tags
+      <jim><jim>jim</jim></jim>
+      was there?
+    HTML
+    sane = Nokogiri::HTML(Loofah.recursive_scrub_fragment(html, :escape).raw_text)
+    assert sane.xpath("//jim").empty?
+  end
+
+  def test_removal_of_a_nested_type2_illegal_tag
+    html = <<-HTML
+      following this there should be no jim tags
+      <<jim>jim>jim<</jim>/jim>
+      was there?
+    HTML
+    sane = Nokogiri::HTML(Loofah.recursive_scrub_fragment(html, :escape).raw_text)
+    assert sane.xpath("//jim").empty?
+  end
+
   def test_removal_of_illegal_tag
     html = <<-HTML
       following this there should be no jim tag
@@ -57,8 +77,20 @@ class IntegrationTestAdHoc < Loofah::TestCase
     assert_equal "This fragment has no tags.", Loofah.scrub_fragment("This fragment has no tags.", :escape).to_xml
   end
 
+  def test_fragment_with_no_tags_on_recursive
+    assert_equal "This fragment has no tags.", Loofah.recursive_scrub_fragment("This fragment has no tags.", :escape).to_xml
+  end
+
   def test_fragment_in_p_tag
     assert_equal "<p>This fragment is in a p.</p>", Loofah.scrub_fragment("<p>This fragment is in a p.</p>", :escape).to_xml
+  end
+
+  def test_fragment_in_p_tag_plus_stuff_on_recursive
+    assert_equal "<p>This fragment is in a p.</p>foo<strong>bar</strong>", Loofah.recursive_scrub_fragment("<p>This fragment is in a p.</p>foo<strong>bar</strong>", :escape).to_xml
+  end
+
+  def test_fragment_with_text_nodes_leading_and_trailing_on_recursive
+    assert_equal "text<p>fragment</p>text", Loofah.recursive_scrub_fragment("text<p>fragment</p>text", :escape).to_xml
   end
 
   def test_fragment_in_p_tag_plus_stuff

--- a/test/integration/test_scrubbers.rb
+++ b/test/integration/test_scrubbers.rb
@@ -230,6 +230,13 @@ class IntegrationTestScrubbers < Loofah::TestCase
           assert_equal INVALID_PRUNED, doc.xpath("./div").inner_html
           assert_equal doc, result
         end
+        it "should retain the behaviour on recursive pruning" do
+          doc = Loofah::HTML::DocumentFragment.parse "<div>#{INVALID_FRAGMENT}</div>"
+          result = doc.scrub! :prune, 3, true
+
+          assert_equal INVALID_PRUNED, doc.xpath("./div").inner_html
+          assert_equal doc, result
+        end
       end
 
       context ":strip" do
@@ -240,12 +247,29 @@ class IntegrationTestScrubbers < Loofah::TestCase
           assert_equal INVALID_STRIPPED, doc.xpath("./div").inner_html
           assert_equal doc, result
         end
+
+
+        it "should retain the behaviour on recursive stripping" do
+          doc = Loofah::HTML::DocumentFragment.parse "<div>#{INVALID_FRAGMENT}</div>"
+          result = doc.scrub! :strip, 3, true
+
+          assert_equal INVALID_STRIPPED, doc.xpath("./div").inner_html
+          assert_equal doc, result
+        end
       end
 
       context ":whitewash" do
         it "whitewash the markup" do
           doc = Loofah::HTML::DocumentFragment.parse "<div>#{WHITEWASH_FRAGMENT}</div>"
           result = doc.scrub! :whitewash
+
+          assert_equal WHITEWASH_RESULT, doc.xpath("./div").inner_html
+          assert_equal doc, result
+        end
+
+        it "should retain the behaviour on recursive whitewashed markup" do
+          doc = Loofah::HTML::DocumentFragment.parse "<div>#{WHITEWASH_FRAGMENT}</div>"
+          result = doc.scrub! :whitewash, 3, true
 
           assert_equal WHITEWASH_RESULT, doc.xpath("./div").inner_html
           assert_equal doc, result
@@ -262,6 +286,14 @@ class IntegrationTestScrubbers < Loofah::TestCase
             assert_equal NOFOLLOW_RESULT, doc.xpath("./div").inner_html
             assert_equal doc, result
           end
+
+          it "should retain the behaviour on recursive nofollow" do
+            doc = Loofah::HTML::DocumentFragment.parse "<div>#{NOFOLLOW_FRAGMENT}</div>"
+            result = doc.scrub! :nofollow, 3, true
+
+            assert_equal NOFOLLOW_RESULT, doc.xpath("./div").inner_html
+            assert_equal doc, result
+          end
         end
 
         context "for a hyperlink that does have a rel attribute" do
@@ -271,6 +303,14 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
               assert_equal NOFOLLOW_WITH_REL_RESULT, doc.xpath("./div").inner_html
               assert_equal doc, result
+          end
+
+          it "should retain the behaviour on recursive nofollow" do
+            doc = Loofah::HTML::DocumentFragment.parse "<div>#{NOFOLLOW_WITH_REL_FRAGMENT}</div>"
+            result = doc.scrub! :nofollow, 3, true
+
+            assert_equal NOFOLLOW_WITH_REL_RESULT, doc.xpath("./div").inner_html
+            assert_equal doc, result
           end
         end
 
@@ -286,12 +326,28 @@ class IntegrationTestScrubbers < Loofah::TestCase
             assert_equal NOOPENER_RESULT, doc.xpath("./div").inner_html
             assert_equal doc, result
           end
+
+          it "should retain the behaviour on  'noopener' recursive hyperlink" do
+            doc = Loofah::HTML::DocumentFragment.parse "<div>#{NOOPENER_FRAGMENT}</div>"
+            result = doc.scrub! :noopener, 3, true
+
+            assert_equal NOOPENER_RESULT, doc.xpath("./div").inner_html
+            assert_equal doc, result
+          end
         end
 
         context "for a hyperlink that does have a rel attribute" do
           it "appends 'noopener' to 'rel' attribute" do
             doc = Loofah::HTML::DocumentFragment.parse "<div>#{NOOPENER_WITH_REL_FRAGMENT}</div>"
             result = doc.scrub! :noopener
+
+            assert_equal NOOPENER_WITH_REL_RESULT, doc.xpath("./div").inner_html
+            assert_equal doc, result
+          end
+
+          it "should retain the behaviour on  'noopener' recursive hyperlink" do
+            doc = Loofah::HTML::DocumentFragment.parse "<div>#{NOOPENER_WITH_REL_FRAGMENT}</div>"
+            result = doc.scrub! :noopener, 3, true
 
             assert_equal NOOPENER_WITH_REL_RESULT, doc.xpath("./div").inner_html
             assert_equal doc, result
@@ -307,6 +363,14 @@ class IntegrationTestScrubbers < Loofah::TestCase
           assert_equal UNPRINTABLE_RESULT, doc.xpath("./div").inner_html
           assert_equal doc, result
         end
+
+        it "should retain the behaviour on  unprintable recursive" do
+          doc = Loofah::HTML::DocumentFragment.parse "<div>#{UNPRINTABLE_FRAGMENT}</div>"
+          result = doc.scrub! :unprintable, 3, true
+
+          assert_equal UNPRINTABLE_RESULT, doc.xpath("./div").inner_html
+          assert_equal doc, result
+        end
       end
     end
 
@@ -317,6 +381,16 @@ class IntegrationTestScrubbers < Loofah::TestCase
         mock(mock_doc).scrub!(:method)
 
         Loofah.scrub_fragment(:string_or_io, :method)
+      end
+    end
+
+    context "#recursive_scrub_fragment" do
+      it "be a shortcut for parse-and-scrub with arguments :times = 3, true" do
+        mock_doc = Object.new
+        mock(Loofah).fragment(:string_or_io) { mock_doc }
+        mock(mock_doc).scrub!(:method, 3, true)
+
+        Loofah.recursive_scrub_fragment(:string_or_io, :method)
       end
     end
 


### PR DESCRIPTION
This is a solution to: https://github.com/flavorjones/loofah/issues/127

**Regarding the solution:**
I found that there was no easy way to sort this at the node level, as the problem is specifically that sibling nodes could, together after destroying a middle node become problematic.
I chose to restart a clean on fragments and documents if their representation `raw_text` was deemed to be problematic.

**Regarding defaults:**
Due to some existing expectations on the specs, the proposed solution is not 100% retrocompatible, hence I introduced the new 'safer' method recursive_scrub_fragment (and document).

**Regarding testing**
I did integration testing to make sure that: we are modifying the behaviour as slightly as possible.
We solve the nested script validation issue.