### PR TITLE
Fix inaccurate example in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -114,7 +114,7 @@ Loofah overrides +to_s+ to return HTML:
 
   unsafe_html = "ohai! <div>div is safe</div> <script>but script is not</script>"
 
-  doc = Loofah.fragment(unsafe_html).scrub!(:strip)
+  doc = Loofah.fragment(unsafe_html).scrub!(:prune)
   doc.to_s    # => "ohai! <div>div is safe</div> "
 
 and +text+ to return plain text:


### PR DESCRIPTION
The example:
```
unsafe_html = "ohai! <div>div is safe</div> <script>but script is not</script>"

doc = Loofah.fragment(unsafe_html).scrub!(:strip)
doc.to_s    # => "ohai! <div>div is safe</div> "
```
was not true to Loofah's output. Using the `:strip` scrubber would remove the `<script>` tag but leave its children, meaning that the actual value returned by `doc.to_s` would be:
```
"ohai! <div>div is safe</div> but script is not"
```
not:
```
"ohai! <div>div is safe</div> "
```

Using the `:prune` scrubber, on the other hand, removes the `<script>` tag along with its children, resulting in the latter value for `to_s`.