### PR TITLE
Added list-style-type as a safe CSS property to whitelist

### DIFF
--- a/lib/loofah/html5/whitelist.rb
+++ b/lib/loofah/html5/whitelist.rb
@@ -125,8 +125,8 @@ module Loofah
       border-bottom-color border-collapse border-color border-left-color
       border-right-color border-top-color clear color cursor direction
       display elevation float font font-family font-size font-style
-      font-variant font-weight height letter-spacing line-height overflow
-      pause pause-after pause-before pitch pitch-range richness speak
+      font-variant font-weight height letter-spacing line-height list-style-type
+      overflow pause pause-after pause-before pitch pitch-range richness speak
       speak-header speak-numeral speak-punctuation speech-rate stress
       text-align text-decoration text-indent unicode-bidi vertical-align
       voice-family volume white-space width]

--- a/test/html5/test_sanitizer.rb
+++ b/test/html5/test_sanitizer.rb
@@ -136,7 +136,7 @@ class Html5TestSanitizer < Loofah::TestCase
       check_sanitization(input, output, output, output)
     end
   end
-  
+
   HTML5::WhiteList::ALLOWED_URI_DATA_MEDIATYPES.each do |data_uri_type|
     define_method "test_should_allow_data_#{data_uri_type}_uris" do
       input = %(<a href="data:#{data_uri_type}">foo</a>)
@@ -279,6 +279,12 @@ class Html5TestSanitizer < Loofah::TestCase
     html = "<span style=\"width:calc(5%)\">"
     sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :strip).to_html)
     assert_match %r/calc\(5%\)/, sane.inner_html
+  end
+
+  def test_css_function_sanitization_leaves_whitelisted_list_style_type
+    html = "<ol style='list-style-type:lower-greek;'></ol>"
+    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :strip).to_html)
+    assert_match %r/list-style-type:lower-greek/, sane.inner_html
   end
 
   def test_css_function_sanitization_strips_style_attributes_with_unsafe_functions


### PR DESCRIPTION
In an effort to expedite the addition of list-style-type on PR #137 I've made this PR which removes the issues with version manipulation