### PR TITLE
Allow greater precision in values of shorthand css elements

### DIFF
--- a/lib/loofah/html5/scrub.rb
+++ b/lib/loofah/html5/scrub.rb
@@ -6,7 +6,7 @@ module Loofah
     module Scrub
 
       CONTROL_CHARACTERS = /[`\u0000-\u0020\u007f\u0080-\u0101]/
-      CSS_KEYWORDISH = /\A(#[0-9a-f]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|-?\d{0,2}\.?\d{0,2}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)\z/
+      CSS_KEYWORDISH = /\A(#[0-9a-f]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|-?\d{0,3}\.?\d{0,10}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)\z/
       CRASS_SEMICOLON = {:node => :semicolon, :raw => ";"}
 
       class << self


### PR DESCRIPTION
The current regular expression for determining valid shorthand css is very restrictive and only allows 2 digits on the integer portion as well as the 2 digits in the fractional portion of a css value. 
This PR increases the range of valid css values.
For example, `margin-left: 0.334px` was previously sanitized by the html scrubber, but will now be preserved.

Issue: https://github.com/flavorjones/loofah/issues/149