### PR TITLE
Allow CSS property `list-style`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Features:
 * Expand set of allowed protocols to include `tel:` and `line:`. [#104, #147]
 * Expand set of allowed CSS functions. [related to #122]
 * Allow greater precision in shorthand CSS values. [#149] (Thanks, @danfstucky!)
+* Allow CSS property `list-style`
 
 
 ## 2.2.3 / 2018-10-30

--- a/lib/loofah/html5/whitelist.rb
+++ b/lib/loofah/html5/whitelist.rb
@@ -574,6 +574,7 @@ module Loofah
                                             "height",
                                             "letter-spacing",
                                             "line-height",
+                                            "list-style",
                                             "list-style-type",
                                             "overflow",
                                             "pause",

--- a/test/html5/test_sanitizer.rb
+++ b/test/html5/test_sanitizer.rb
@@ -263,6 +263,12 @@ class Html5TestSanitizer < Loofah::TestCase
     end
   end
 
+  def test_css_list_style
+    html = '<ul style="list-style: none"></ul>'
+    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    assert_match %r/list-style/, sane.inner_html
+  end
+
   def test_css_negative_value_sanitization
     html = "<span style=\"letter-spacing:-0.03em;\">"
     sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)


### PR DESCRIPTION
Hello, first time contributing to loofah. I'm not sure if this should go in `ACCEPTABLE_CSS_PROPERTIES` or in `SHORTHAND_CSS_PROPERTIES` but of those two, only the former makes my test pass.