### PR TITLE
Correct the regexp for kewordish css property which hold hex values

### DIFF
--- a/lib/loofah/html5/scrub.rb
+++ b/lib/loofah/html5/scrub.rb
@@ -6,7 +6,7 @@ module Loofah
     module Scrub
 
       CONTROL_CHARACTERS = /[`\u0000-\u0020\u007f\u0080-\u0101]/
-      CSS_KEYWORDISH = /\A(#[0-9a-f]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|-?\d{0,3}\.?\d{0,10}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)\z/
+      CSS_KEYWORDISH = /\A(#[0-9a-fA-F]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|-?\d{0,3}\.?\d{0,10}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)\z/
       CRASS_SEMICOLON = {:node => :semicolon, :raw => ";"}
 
       class << self

--- a/test/html5/test_scrub.rb
+++ b/test/html5/test_scrub.rb
@@ -4,7 +4,7 @@ class UnitHTML5Scrub < Loofah::TestCase
   include Loofah
 
   def test_scrub_css
-    assert Loofah::HTML5::Scrub.scrub_css("background: #ABC012"), "background: #ABC012"
-    assert Loofah::HTML5::Scrub.scrub_css("background: #abc012"), "background: #abc012"
+    assert_equal Loofah::HTML5::Scrub.scrub_css("background: #ABC012"), "background:#ABC012;"
+    assert_equal Loofah::HTML5::Scrub.scrub_css("background: #abc012"), "background:#abc012;"
   end
 end

--- a/test/html5/test_scrub.rb
+++ b/test/html5/test_scrub.rb
@@ -1,0 +1,10 @@
+require "helper"
+
+class UnitHTML5Scrub < Loofah::TestCase
+  include Loofah
+
+  def test_scrub_css
+    assert Loofah::HTML5::Scrub.scrub_css("background: #ABC012"), "background: #ABC012"
+    assert Loofah::HTML5::Scrub.scrub_css("background: #abc012"), "background: #abc012"
+  end
+end


### PR DESCRIPTION
```rb
Loofah::HTML5::Scrub.scrub_css("background: #0000A") # => ""
```

Should behave the same as

```rb
Loofah::HTML5::Scrub.scrub_css("background: #0000a") # => "background:#0000a;"
```
