### PR TITLE
Allow the thin and thick CSS keywords

### DIFF
--- a/lib/loofah/html5/whitelist.rb
+++ b/lib/loofah/html5/whitelist.rb
@@ -635,6 +635,8 @@ module Loofah
                                           "silver",
                                           "solid",
                                           "teal",
+                                          "thin",
+                                          "thick",
                                           "top",
                                           "transparent",
                                           "underline",


### PR DESCRIPTION
They're used as values for the `border-width` property, which can be specified via the currently-allowed `border` shorthand property. (`medium` can also be used as a `border-width` value and is already allowed.)

See the [`<line-width>`](https://www.w3.org/TR/css-backgrounds-3/#typedef-line-width) type definition in the Backgrounds and Borders module of the CSS spec.