### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/loofah.gemspec
+++ b/loofah.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
     'bug_tracker_uri'   => 'https://github.com/flavorjones/loofah/issues',
     'changelog_uri'     => "https://github.com/flavorjones/loofah/blob/v#{s.version}/CHANGELOG.md",
     'documentation_uri' => "https://www.rubydoc.info/gems/loofah/#{s.version}",
-    'mailing_list_uri'  => 'http://librelist.com/browser/loofah/',
+    'mailing_list_uri'  => 'https://groups.google.com/forum/#!forum/loofah-talk',
     'source_code_uri'   => "https://github.com/flavorjones/loofah/tree/v#{s.version}",
     'wiki_uri'          => 'https://github.com/flavorjones/loofah/wiki'
   }

--- a/loofah.gemspec
+++ b/loofah.gemspec
@@ -19,6 +19,15 @@ Gem::Specification.new do |s|
   s.rubygems_version = "3.0.3".freeze
   s.summary = "Loofah is a general library for manipulating and transforming HTML/XML documents and fragments, built on top of Nokogiri".freeze
 
+  s.metadata = {
+    'bug_tracker_uri'   => 'https://github.com/flavorjones/loofah/issues',
+    'changelog_uri'     => "https://github.com/flavorjones/loofah/blob/v#{s.version}/CHANGELOG.md",
+    'documentation_uri' => "https://www.rubydoc.info/gems/loofah/#{s.version}",
+    'mailing_list_uri'  => 'http://librelist.com/browser/loofah/',
+    'source_code_uri'   => "https://github.com/flavorjones/loofah/tree/v#{s.version}",
+    'wiki_uri'          => 'https://github.com/flavorjones/loofah/wiki'
+  }
+
   if s.respond_to? :specification_version then
     s.specification_version = 4
 


### PR DESCRIPTION
Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues and read the changelog. These `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `mailing_list_uri`, `wiki_uri` and `source_code_uri` links will appear on the rubygems page at https://rubygems.org/gems/loofah and be available via the rubygems API after the next release.