### PR TITLE
Fix metadata of final gemspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,13 @@ Hoe.spec "loofah" do
   self.history_file = "CHANGELOG.md"
   self.readme_file = "README.md"
   self.license "MIT"
+  self.urls = {
+    "home" => "https://github.com/flavorjones/loofah",
+    "bugs" => "https://github.com/flavorjones/loofah/issues",
+    "doco" => "https://www.rubydoc.info/gems/loofah/",
+    "clog" => "https://github.com/flavorjones/loofah/master/CHANGELOG.md",
+    "code" => "https://github.com/flavorjones/loofah",
+  }
 
   extra_deps << ["nokogiri", ">=1.5.9"]
   extra_deps << ["crass", "~> 1.0.2"]

--- a/loofah.gemspec
+++ b/loofah.gemspec
@@ -20,15 +20,6 @@ Gem::Specification.new do |s|
   s.rubygems_version = "3.0.3".freeze
   s.summary = "Loofah is a general library for manipulating and transforming HTML/XML documents and fragments, built on top of Nokogiri".freeze
 
-  s.metadata = {
-    'bug_tracker_uri'   => 'https://github.com/flavorjones/loofah/issues',
-    'changelog_uri'     => "https://github.com/flavorjones/loofah/blob/v#{s.version}/CHANGELOG.md",
-    'documentation_uri' => "https://www.rubydoc.info/gems/loofah/#{s.version}",
-    'mailing_list_uri'  => 'https://groups.google.com/forum/#!forum/loofah-talk',
-    'source_code_uri'   => "https://github.com/flavorjones/loofah/tree/v#{s.version}",
-    'wiki_uri'          => 'https://github.com/flavorjones/loofah/wiki'
-  }
-
   if s.respond_to? :specification_version then
     s.specification_version = 4
 


### PR DESCRIPTION
#170 added metadata to the `loofah.gemspec`. These changes should be made to README. The `::` syntax is recommended by https://github.com/seattlerb/hoe/commit/e23f9803aefb2e283ba8211235d309ff94b55e9a.

This Pull Request is pending with https://github.com/seattlerb/hoe/pull/98/ to have metadata uri support for `wiki_uri` and `mailing_list_uri`.