### PR TITLE
Allow rewriting constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,19 @@ Loofah::Helpers.strip_tags, both of which are drop-in replacements for
 the Rails ActionView helpers of the same name.
 These are no longer required automatically. You must require `loofah/helpers`. 
 
+### Redefining Safelist
+The class method Loofah.redefine_allowed_safelist_constant can be used 
+for redefining safelist values, that can be found in Safelist.rb
+
+``` ruby
+Loofah.redefine_allowed_safelist_constant(constant_name, values)
+
+Loofah.redefine_allowed_safelist_constant(:ALLOWED_CSS_PROPERTIES, %w(color)) 
+# => #<Set: {"b"}>
+Loofah::HTML5::SafeList::ALLOWED_CSS_PROPERTIES 
+# => #<Set: {"b"}>
+```
+
 
 ## Requirements
 

--- a/lib/loofah.rb
+++ b/lib/loofah.rb
@@ -44,7 +44,7 @@ module Loofah
       Loofah::HTML::DocumentFragment.parse(*args, &block)
     end
 
-    # Shortcut for Loofah::MetaHelpers.redefine_allowed_safelist_constant(constant_name, values)
+    # Shortcut for Loofah::HTML5::SafeList.redefine_allowed_safelist_constant(constant_name, values)
     def redefine_allowed_safelist_constant(constant_name, values)
       Loofah::HTML5::SafeList.redefine_allowed_safelist_constant(constant_name, values) 
     end

--- a/lib/loofah.rb
+++ b/lib/loofah.rb
@@ -44,6 +44,11 @@ module Loofah
       Loofah::HTML::DocumentFragment.parse(*args, &block)
     end
 
+    # Shortcut for Loofah::MetaHelpers.redefine_allowed_safelist_constant(constant_name, values)
+    def redefine_allowed_safelist_constant(constant_name, values)
+      Loofah::HTML5::SafeList.redefine_allowed_safelist_constant(constant_name, values) 
+    end
+
     # Shortcut for Loofah.fragment(string_or_io).scrub!(method)
     def scrub_fragment(string_or_io, method)
       Loofah.fragment(string_or_io).scrub!(method)

--- a/lib/loofah/html5/safelist.rb
+++ b/lib/loofah/html5/safelist.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "set"
+require "loofah/html5/safelist/redefinable_constants"
 
 module Loofah
   module HTML5 # :nodoc:
@@ -46,6 +47,8 @@ module Loofah
     #
     # </html5_license>
     module SafeList
+      include RedefinableConstants
+
       ACCEPTABLE_ELEMENTS = Set.new([
                                       "a",
                                       "abbr",

--- a/lib/loofah/html5/safelist/redefinable_constants.rb
+++ b/lib/loofah/html5/safelist/redefinable_constants.rb
@@ -1,0 +1,35 @@
+#
+# frozen_string_literal: true
+module Loofah
+
+  #
+  #  A RuntimeError raised when Loofah could not find an appropriate constant name in SafeList.
+  #
+  class AllowedConstantNotFound < RuntimeError; end
+
+  module HTML5
+    module SafeList
+      module RedefinableConstants
+        def self.included(base)
+          base.extend(ClassMethods)
+        end
+
+        module ClassMethods
+          # constant_name is one of constant names from SafeList
+          def redefine_allowed_safelist_constant(constant_name, values)
+            constantized_name = constant_name.to_s.upcase
+            values_set = Set.new(values)
+
+            unless const_defined?(constantized_name)
+              raise AllowedConstantNotFound, "No constant with #{constantized_name} name has been defined in SafeList"
+            end
+
+            remove_const(constantized_name)
+
+            self.const_set(constantized_name, values_set)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow reassigning consts from Loofah::HTML5::SafeList, by class method `Loofah.redefine_allowed_safelist_constant(const_name, values)`

Reason for this PR: lack of ability to customise css_properties from SafeList , which leads to monkeypatching Loofah::HTML5::SafeList
