### PR TITLE
Fix CHANGELOG url  in gemspec

### DIFF
--- a/loofah.gemspec
+++ b/loofah.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.version = "2.5.0.20200405164942"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
-  s.metadata = { "bug_tracker_uri" => "https://github.com/flavorjones/loofah/issues", "changelog_uri" => "https://github.com/flavorjones/loofah/master/CHANGELOG.md", "documentation_uri" => "https://www.rubydoc.info/gems/loofah/", "homepage_uri" => "https://github.com/flavorjones/loofah", "source_code_uri" => "https://github.com/flavorjones/loofah" } if s.respond_to? :metadata=
+  s.metadata = { "bug_tracker_uri" => "https://github.com/flavorjones/loofah/issues", "changelog_uri" => "https://github.com/flavorjones/loofah/blob/master/CHANGELOG.md", "documentation_uri" => "https://www.rubydoc.info/gems/loofah/", "homepage_uri" => "https://github.com/flavorjones/loofah", "source_code_uri" => "https://github.com/flavorjones/loofah" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Mike Dalessio".freeze, "Bryan Helmkamp".freeze]
   s.date = "2020-04-05"

--- a/loofah.gemspec
+++ b/loofah.gemspec
@@ -1,6 +1,8 @@
 # -*- encoding: utf-8 -*-
 # stub: loofah 2.5.0.20200405164942 ruby lib
 
+require_relative "lib/loofah"
+
 Gem::Specification.new do |s|
   s.name = "loofah".freeze
   s.version = "2.5.0.20200405164942"
@@ -8,7 +10,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/flavorjones/loofah/issues",
-    "changelog_uri" => "https://github.com/flavorjones/loofah/blob/master/CHANGELOG.md",
+    "changelog_uri" => "https://github.com/flavorjones/loofah/blob/v#{Loofah::VERSION}/CHANGELOG.md",
     "documentation_uri" => "https://www.rubydoc.info/gems/loofah/",
     "homepage_uri" => "https://github.com/flavorjones/loofah",
     "source_code_uri" => "https://github.com/flavorjones/loofah"

--- a/loofah.gemspec
+++ b/loofah.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/flavorjones/loofah/issues",
     "changelog_uri" => "https://github.com/flavorjones/loofah/blob/v#{Loofah::VERSION}/CHANGELOG.md",
-    "documentation_uri" => "https://www.rubydoc.info/gems/loofah/",
+    "documentation_uri" => "https://www.rubydoc.info/gems/loofah/#{Loofah::VERSION}",
     "homepage_uri" => "https://github.com/flavorjones/loofah",
     "source_code_uri" => "https://github.com/flavorjones/loofah"
   } if s.respond_to? :metadata=

--- a/loofah.gemspec
+++ b/loofah.gemspec
@@ -6,7 +6,13 @@ Gem::Specification.new do |s|
   s.version = "2.5.0.20200405164942"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
-  s.metadata = { "bug_tracker_uri" => "https://github.com/flavorjones/loofah/issues", "changelog_uri" => "https://github.com/flavorjones/loofah/blob/master/CHANGELOG.md", "documentation_uri" => "https://www.rubydoc.info/gems/loofah/", "homepage_uri" => "https://github.com/flavorjones/loofah", "source_code_uri" => "https://github.com/flavorjones/loofah" } if s.respond_to? :metadata=
+  s.metadata = {
+    "bug_tracker_uri" => "https://github.com/flavorjones/loofah/issues",
+    "changelog_uri" => "https://github.com/flavorjones/loofah/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://www.rubydoc.info/gems/loofah/",
+    "homepage_uri" => "https://github.com/flavorjones/loofah",
+    "source_code_uri" => "https://github.com/flavorjones/loofah"
+  } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Mike Dalessio".freeze, "Bryan Helmkamp".freeze]
   s.date = "2020-04-05"


### PR DESCRIPTION
The recently added  changelog url in gemspec does not work:
https://github.com/flavorjones/loofah/master/CHANGELOG.md
See also on [RubyGems](https://rubygems.org/gems/loofah).

The correct url is https://github.com/flavorjones/loofah/blob/master/CHANGELOG.md

It is also recommended to use the version number in the url: https://github.com/flavorjones/loofah/blob/v2.5.0/CHANGELOG.md

I have not only corrected the URL, but also added a  a version specific url to the changelog and to the rubydocs.