### PR TITLE
Update safelist.rb to include overflow-x and y

### DIFF
--- a/lib/loofah/html5/safelist.rb
+++ b/lib/loofah/html5/safelist.rb
@@ -588,6 +588,8 @@ module Loofah
                                             "max-width",
                                             "order",
                                             "overflow",
+                                            "overflow-x",
+                                            "overflow-y",
                                             "page-break-after",
                                             "page-break-before",
                                             "page-break-inside",


### PR DESCRIPTION
Just run into the problem of overflow-x and y disappearing. 
It seems like the end-goal is to not to have to maintain a list like this, but at least in my use case overflow-y is used quite a bit. 
So it would be pretty great to have it as allowed property too!