### PR TITLE
test: libxml 2.9.11 handles namespaces in HTML docs differently

### DIFF
--- a/test/integration/test_ad_hoc.rb
+++ b/test/integration/test_ad_hoc.rb
@@ -79,13 +79,20 @@ class IntegrationTestAdHoc < Loofah::TestCase
 
     def test_fragment_whitewash_on_microsofty_markup
       whitewashed = Loofah.fragment(MSWORD_HTML).scrub!(:whitewash)
-      assert_equal "<p>Foo <b>BOLD</b></p>", whitewashed.to_s.strip
+      if Nokogiri.uses_libxml?("<2.9.11")
+        assert_equal "<p>Foo <b>BOLD</b></p>", whitewashed.to_s.strip
+      else
+        assert_equal "<p>Foo <b>BOLD<p></p></b></p>", whitewashed.to_s.strip
+      end
     end
 
     def test_document_whitewash_on_microsofty_markup
       whitewashed = Loofah.document(MSWORD_HTML).scrub!(:whitewash)
-      assert_match %r(<p>Foo <b>BOLD</b></p>), whitewashed.to_s
-      assert_equal "<p>Foo <b>BOLD</b></p>", whitewashed.xpath("/html/body/*").to_s
+      if Nokogiri.uses_libxml?("<2.9.11")
+        assert_equal "<p>Foo <b>BOLD</b></p>", whitewashed.xpath("/html/body/*").to_s
+      else
+        assert_equal "<p>Foo <b>BOLD<p></p></b></p>", whitewashed.xpath("/html/body/*").to_s
+      end
     end
 
     def test_return_empty_string_when_nothing_left

--- a/test/integration/test_scrubbers.rb
+++ b/test/integration/test_scrubbers.rb
@@ -8,6 +8,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
   WHITEWASH_FRAGMENT = "<o:div>no</o:div><div id='no'>foo</div><invalid>bar</invalid><!--[if gts mso9]><div>microsofty stuff</div><![endif]-->"
   WHITEWASH_RESULT = "<div>foo</div>"
+  WHITEWASH_RESULT_LIBXML2911 = "<div>no</div>\n<div>foo</div>"
 
   NOFOLLOW_FRAGMENT = '<a href="http://www.example.com/">Click here</a>'
   NOFOLLOW_RESULT = '<a href="http://www.example.com/" rel="nofollow">Click here</a>'
@@ -68,7 +69,8 @@ class IntegrationTestScrubbers < Loofah::TestCase
           doc = Loofah::HTML::Document.parse "<html><body>#{WHITEWASH_FRAGMENT}</body></html>"
           result = doc.scrub! :whitewash
 
-          assert_equal WHITEWASH_RESULT, doc.xpath("/html/body").inner_html
+          ww_result = Nokogiri.uses_libxml?("<2.9.11") ? WHITEWASH_RESULT : WHITEWASH_RESULT_LIBXML2911
+          assert_equal ww_result, doc.xpath("/html/body").inner_html
           assert_equal doc, result
         end
       end
@@ -246,7 +248,8 @@ class IntegrationTestScrubbers < Loofah::TestCase
           doc = Loofah::HTML::DocumentFragment.parse "<div>#{WHITEWASH_FRAGMENT}</div>"
           result = doc.scrub! :whitewash
 
-          assert_equal WHITEWASH_RESULT, doc.xpath("./div").inner_html
+          ww_result = Nokogiri.uses_libxml?("<2.9.11") ? WHITEWASH_RESULT : WHITEWASH_RESULT_LIBXML2911
+          assert_equal ww_result, doc.xpath("./div").inner_html
           assert_equal doc, result
         end
       end


### PR DESCRIPTION
Update tests to pass with this version of libxml2. See https://gitlab.gnome.org/GNOME/libxml2/-/commit/21ca882