### PR TITLE
add 'wbr' tag to safelist

### DIFF
--- a/lib/loofah/html5/safelist.rb
+++ b/lib/loofah/html5/safelist.rb
@@ -800,6 +800,7 @@ module Loofah
                                 "link",
                                 "meta",
                                 "param",
+                                "wbr",
                               ])
 
       # additional tags we should consider safe since we have libxml2 fixing up our documents.


### PR DESCRIPTION
`wbr` tag is an empty HTML element, but not supported loofah so added it to support list.
ref: https://developer.mozilla.org/en-US/docs/Glossary/Empty_element