### PR TITLE
allow HTML5 element `wbr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## next / unreleased
+
+### Changes
+
+* Deprecating `Loofah::HTML5::SafeList::VOID_ELEMENTS` which is not a canonical list of void HTML4 or HTML5 elements.
+* Removed some elements from `Loofah::HTML5::SafeList::VOID_ELEMENTS` that either are not acceptable elements or aren't considered "void" by libxml2.
+
+
 ## 2.10.0 / 2021-06-06
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## next / unreleased
 
+### Features
+
+* Allow HTML5 element `wbr`.
+
+
 ### Changes
 
 * Deprecating `Loofah::HTML5::SafeList::VOID_ELEMENTS` which is not a canonical list of void HTML4 or HTML5 elements.

--- a/lib/loofah/html5/safelist.rb
+++ b/lib/loofah/html5/safelist.rb
@@ -140,6 +140,7 @@ module Loofah
                                       "ul",
                                       "var",
                                       "video",
+                                      "wbr",
                                     ])
 
       MATHML_ELEMENTS = Set.new([

--- a/lib/loofah/html5/safelist.rb
+++ b/lib/loofah/html5/safelist.rb
@@ -788,18 +788,14 @@ module Loofah
       ALLOWED_PROTOCOLS = ACCEPTABLE_PROTOCOLS
       ALLOWED_URI_DATA_MEDIATYPES = ACCEPTABLE_URI_DATA_MEDIATYPES
 
+      # TODO: remove VOID_ELEMENTS in a future major release
+      # and put it in the tests (it is used only for testing, not for functional behavior)
       VOID_ELEMENTS = Set.new([
                                 "area",
-                                "base",
                                 "br",
-                                "col",
-                                "embed",
                                 "hr",
                                 "img",
                                 "input",
-                                "link",
-                                "meta",
-                                "param",
                               ])
 
       # additional tags we should consider safe since we have libxml2 fixing up our documents.

--- a/test/html5/test_sanitizer.rb
+++ b/test/html5/test_sanitizer.rb
@@ -68,6 +68,12 @@ class Html5TestSanitizer < Loofah::TestCase
     end
   end
 
+  HTML5::SafeList::VOID_ELEMENTS.each do |tag_name|
+    define_method "test_void_#{tag_name}_is_in_allowed_list" do
+      assert_includes(HTML5::SafeList::ALLOWED_ELEMENTS, tag_name)
+    end
+  end
+
   ##
   ##  libxml2 downcases elements, so this is moot.
   ##


### PR DESCRIPTION
This PR introduces some changes:

- deprecate `HTML5::SafeList::VOID_ELEMENTS` which is not a canonical set of void elements
- remove unallowed elements from VOID_ELEMENTS
- remove elements that libxml2 doesn't actually treat as void from VOID_ELEMENTS
- allow `wbr` element

See #212 for background. See also https://developer.mozilla.org/en-US/docs/Glossary/Empty_element