### PR TITLE
test: use CSS hex-encoded strings to test sanitization

### DIFF
--- a/test/assets/testdata_sanitizer_tests1.dat
+++ b/test/assets/testdata_sanitizer_tests1.dat
@@ -62,6 +62,20 @@
   },
 
   {
+    /* and put that version into a CSS hex-encoded string */
+    "name": "div_background_image_unicode_encoded5",
+    "input": "<DIV STYLE=\"background-image:\\0075\\0072\\006C\\0028\\0027\\006a\\0061\\0076\\0061\\0073\\0063\\0072\\0069\\0070\\0074\\003a\\0061\\006c\\0065\\0072\\0074\\0028\\0031\\0032\\0033\\0034\\0029\\0027\\0029\">foo</div>",
+    "output": "<div>foo</div>"
+  },
+
+  {
+    /* and again without encoding the parens */
+    "name": "div_background_image_unicode_encoded6",
+    "input": "<DIV STYLE=\"background-image:\\0075\\0072\\006C(\\0027\\006a\\0061\\0076\\0061\\0073\\0063\\0072\\0069\\0070\\0074\\003a\\0061\\006c\\0065\\0072\\0074\\0028\\0031\\0032\\0033\\0034\\0029\\0027)\">foo</div>",
+    "output": "<div>foo</div>"
+  },
+
+  {
     "name": "div_expression",
     "input": "<div style=\"width: expression(alert('XSS'));\">foo</div>",
     "output": "<div>foo</div>"


### PR DESCRIPTION
This adds onto #205. The original reported exploit in 2006 used CSS
hex encoding (e.g., "\0075" for "u"), which was ...

- mistakenly put into a double-quoted Ruby string in the Instiki test
  suite in 2007,
- then copied into html5lib-ruby's test suite,
- then copied into html5lib-python's suite,
- then finally copied into the html5lib shared suite,
- which was imported into Loofah