### PR TITLE
test: ensure we pass with libxml 2.9.14

### DIFF
--- a/test/assets/testdata_sanitizer_tests1.dat
+++ b/test/assets/testdata_sanitizer_tests1.dat
@@ -9,7 +9,8 @@
     "name": "IE_Comments_2",
     "input": "<![if !IE 5]><script>alert('XSS');</script><![endif]>",
     "output": "&lt;script&gt;alert('XSS');&lt;/script&gt;",
-    "rexml": "Ill-formed XHTML!"
+    "xhtml": "&lt;![if !IE 5]&gt;&lt;script&gt;alert('XSS');&lt;/script&gt;&lt;![endif]&gt;",
+    "commentary": "output is libxml 2.9.13 and earlier, xhtml is libxml 2.9.14 and later, see libxml 148be64"
   },
 
   {


### PR DESCRIPTION
libxml2 v2.9.14 changes how ill-formed HTML4 is fixed up in recovery mode. See [release notes for Nokogiri v1.13.5](https://github.com/sparklemotion/nokogiri/releases/tag/v1.13.5) and https://github.com/sparklemotion/nokogiri/issues/2525
