### PR TITLE
Add aspect-ratio to the list of css properties

### DIFF
--- a/lib/loofah/html5/safelist.rb
+++ b/lib/loofah/html5/safelist.rb
@@ -617,6 +617,7 @@ module Loofah
                                             "align-content",
                                             "align-items",
                                             "align-self",
+                                            "aspect-ratio",
                                             "background-color",
                                             "border-bottom-color",
                                             "border-collapse",


### PR DESCRIPTION
Hey @flavorjones!

This PR simply adds [`aspect-ratio`](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio) to the list of supported CSS properties.