### PR TITLE
ci: don't fail fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
   test:
     needs: ["rubocop"]
     strategy:
+      fail-fast: false
       matrix:
         ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "head", "truffleruby-head"]
     runs-on: ubuntu-latest


### PR DESCRIPTION
CI has started failing on the Ruby 2.5 suite. Let's fix it!