### PR TITLE
[draft] default to html5 parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,29 @@ jobs:
           bundler-cache: true
       - run: bundle exec rake rubocop
 
-  test:
+  test_html4:
+    env:
+      LOOFAH_HTML4_MODE: "t"
     needs: ["rubocop"]
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "head", "truffleruby-head"]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "head", "truffleruby-head"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{matrix.ruby}}
+          bundler-cache: true
+      - run: bundle exec rake test
+
+  test_html5:
+    needs: ["rubocop"]
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.6", "2.7", "3.0", "3.1", "head", "truffleruby-head"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source "https://rubygems.org/"
 gemspec
+gem "nokogiri", git: "https://github.com/sparklemotion/nokogiri" # main has subclassing fix

--- a/lib/loofah.rb
+++ b/lib/loofah.rb
@@ -4,21 +4,6 @@ $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__))) unless $LOAD_PATH.i
 require "nokogiri"
 
 require_relative "loofah/version"
-require_relative "loofah/metahelpers"
-require_relative "loofah/elements"
-
-require_relative "loofah/html5/safelist"
-require_relative "loofah/html5/libxml2_workarounds"
-require_relative "loofah/html5/scrub"
-
-require_relative "loofah/scrubber"
-require_relative "loofah/scrubbers"
-
-require_relative "loofah/instance_methods"
-require_relative "loofah/xml/document"
-require_relative "loofah/xml/document_fragment"
-require_relative "loofah/html/document"
-require_relative "loofah/html/document_fragment"
 
 # == Strings and IO Objects as Input
 #
@@ -31,13 +16,13 @@ require_relative "loofah/html/document_fragment"
 module Loofah
   class << self
     # Shortcut for Loofah::HTML::Document.parse
-    # This method accepts the same parameters as Nokogiri::HTML::Document.parse
+    # This method accepts the same parameters as Nokogiri::HTML5::Document.parse
     def document(*args, &block)
-      remove_comments_before_html_element Loofah::HTML::Document.parse(*args, &block)
+      remove_comments_before_html_element(Loofah::HTML::Document.parse(*args, &block))
     end
 
     # Shortcut for Loofah::HTML::DocumentFragment.parse
-    # This method accepts the same parameters as Nokogiri::HTML::DocumentFragment.parse
+    # This method accepts the same parameters as Nokogiri::HTML5::DocumentFragment.parse
     def fragment(*args, &block)
       Loofah::HTML::DocumentFragment.parse(*args, &block)
     end
@@ -79,6 +64,25 @@ module Loofah
       string.gsub(/\n\s*\n\s*\n/, "\n\n")
     end
 
+    def html5_mode?
+      defined?(::Nokogiri::HTML5) && (parser_module == ::Nokogiri::HTML5)
+    end
+
+    def parser_module(class_name=nil)
+      @parser_module ||= begin
+        if ENV["LOOFAH_HTML4_MODE"].nil? && defined?(::Nokogiri::HTML5)
+          ::Nokogiri::HTML5
+        else
+          ::Nokogiri::HTML4
+        end
+      end
+      if class_name
+        @parser_module.const_get(class_name)
+      else
+        @parser_module
+      end
+    end
+
     private
 
     # remove comments that exist outside of the HTML element.
@@ -98,3 +102,19 @@ module Loofah
     end
   end
 end
+
+require_relative "loofah/metahelpers"
+require_relative "loofah/elements"
+
+require_relative "loofah/html5/safelist"
+require_relative "loofah/html5/libxml2_workarounds"
+require_relative "loofah/html5/scrub"
+
+require_relative "loofah/scrubber"
+require_relative "loofah/scrubbers"
+
+require_relative "loofah/instance_methods"
+require_relative "loofah/xml/document"
+require_relative "loofah/xml/document_fragment"
+require_relative "loofah/html/document"
+require_relative "loofah/html/document_fragment"

--- a/lib/loofah/html/document.rb
+++ b/lib/loofah/html/document.rb
@@ -2,11 +2,11 @@
 module Loofah
   module HTML # :nodoc:
     #
-    #  Subclass of Nokogiri::HTML::Document.
+    #  Subclass of Nokogiri::HTML5::Document.
     #
     #  See Loofah::ScrubBehavior and Loofah::TextBehavior for additional methods.
     #
-    class Document < Nokogiri::HTML::Document
+    class Document < ::Loofah.parser_module(:Document)
       include Loofah::ScrubBehavior::Node
       include Loofah::DocumentDecorator
       include Loofah::TextBehavior

--- a/lib/loofah/html/document_fragment.rb
+++ b/lib/loofah/html/document_fragment.rb
@@ -2,16 +2,16 @@
 module Loofah
   module HTML # :nodoc:
     #
-    #  Subclass of Nokogiri::HTML::DocumentFragment.
+    #  Subclass of Nokogiri::HTML5::DocumentFragment.
     #
     #  See Loofah::ScrubBehavior and Loofah::TextBehavior for additional methods.
     #
-    class DocumentFragment < Nokogiri::HTML::DocumentFragment
+    class DocumentFragment < ::Loofah.parser_module(:DocumentFragment)
       include Loofah::TextBehavior
 
       class << self
         #
-        #  Overridden Nokogiri::HTML::DocumentFragment
+        #  Overridden Nokogiri::HTML5::DocumentFragment
         #  constructor. Applications should use Loofah.fragment to
         #  parse a fragment.
         #

--- a/lib/loofah/html5/safelist.rb
+++ b/lib/loofah/html5/safelist.rb
@@ -869,6 +869,9 @@ module Loofah
                                 "img",
                                 "input",
                               ])
+      if ::Loofah.html5_mode?
+        VOID_ELEMENTS.add("wbr")
+      end
 
       # additional tags we should consider safe since we have libxml2 fixing up our documents.
       TAGS_SAFE_WITH_LIBXML2 = Set.new([

--- a/lib/loofah/scrubber.rb
+++ b/lib/loofah/scrubber.rb
@@ -103,8 +103,8 @@ module Loofah
     def html5lib_sanitize(node)
       case node.type
       when Nokogiri::XML::Node::ELEMENT_NODE
+        HTML5::Scrub.scrub_attributes node
         if HTML5::Scrub.allowed_element? node.name
-          HTML5::Scrub.scrub_attributes node
           return Scrubber::CONTINUE
         end
       when Nokogiri::XML::Node::TEXT_NODE, Nokogiri::XML::Node::CDATA_SECTION_NODE

--- a/test/assets/testdata_sanitizer_tests1.dat
+++ b/test/assets/testdata_sanitizer_tests1.dat
@@ -30,8 +30,7 @@
   {
     "name": "bgsound",
     "input": "<bgsound src=\"javascript:alert('XSS');\" />",
-    "output": "&lt;bgsound src=\"javascript:alert('XSS');\"/&gt;",
-    "rexml": "&lt;bgsound src=\"javascript:alert('XSS');\"&gt;&lt;/bgsound&gt;"
+    "output": "&lt;bgsound&gt;&lt;/bgsound&gt;"
   },
 
   {
@@ -127,8 +126,7 @@
   {
     "name": "link_stylesheets",
     "input": "<link rel=\"stylesheet\" href=\"javascript:alert('XSS');\" />",
-    "output": "&lt;link rel=\"stylesheet\" href=\"javascript:alert('XSS');\"&gt;",
-    "rexml": "&lt;link href=\"javascript:alert('XSS');\" rel=\"stylesheet\"/&gt;"
+    "output": "&lt;link rel=\"stylesheet\"&gt;"
   },
 
   {

--- a/test/assets/testdata_sanitizer_tests1.dat
+++ b/test/assets/testdata_sanitizer_tests1.dat
@@ -8,9 +8,9 @@
   {
     "name": "IE_Comments_2",
     "input": "<![if !IE 5]><script>alert('XSS');</script><![endif]>",
-    "output": "&lt;script&gt;alert('XSS');&lt;/script&gt;",
-    "xhtml": "&lt;![if !IE 5]&gt;&lt;script&gt;alert('XSS');&lt;/script&gt;&lt;![endif]&gt;",
-    "commentary": "output is libxml 2.9.13 and earlier, xhtml is libxml 2.9.14 and later, see libxml 148be64"
+    "libxml_lte_2.9.13": "&lt;script&gt;alert('XSS');&lt;/script&gt;",
+    "libxml_gte_2.9.14": "&lt;![if !IE 5]&gt;&lt;script&gt;alert('XSS');&lt;/script&gt;&lt;![endif]&gt;",
+    "libgumbo": "&lt;!--[if !IE 5]--&gt;&lt;script&gt;alert('XSS');&lt;/script&gt;&lt;!--[endif]--&gt;"
   },
 
   {
@@ -30,7 +30,8 @@
   {
     "name": "bgsound",
     "input": "<bgsound src=\"javascript:alert('XSS');\" />",
-    "output": "&lt;bgsound&gt;&lt;/bgsound&gt;"
+    "libxml": "&lt;bgsound&gt;&lt;/bgsound&gt;",
+    "libgumbo": "&lt;bgsound&gt;"
   },
 
   {
@@ -84,15 +85,27 @@
   {
     "name": "double_open_angle_brackets",
     "input": "<img src=http://ha.ckers.org/scriptlet.html <",
-    "output": "<img src='http://ha.ckers.org/scriptlet.html'>",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "<img src='http://ha.ckers.org/scriptlet.html'>",
+    "libgumbo": "" /* it is indeed the empty result, see next test for a better test */
+  },
+
+  {
+    "name": "double_open_angle_brackets v2",
+    "input": "<div><img src=http://ha.ckers.org/scriptlet.html < </div>",
+    "output": "<div><img src='http://ha.ckers.org/scriptlet.html'></div>"
   },
 
   {
     "name": "double_open_angle_brackets_2",
     "input": "<script src=http://ha.ckers.org/scriptlet.html <",
-    "output": "&lt;script src=\"http://ha.ckers.org/scriptlet.html\"&gt;&lt;/script&gt;",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "&lt;script src=\"http://ha.ckers.org/scriptlet.html\"&gt;&lt;/script&gt;",
+    "libgumbo": "" /* it is indeed empty */
+  },
+
+  {
+    "name": "double_open_angle_brackets_2 v2",
+    "input": "<div><script src=http://ha.ckers.org/scriptlet.html < </div>",
+    "libxml": "<div>&lt;script src=\"http://ha.ckers.org/scriptlet.html\"&gt;&lt;/script&gt;</div>"
   },
 
   {
@@ -132,8 +145,7 @@
   {
     "name": "link_stylesheets_2",
     "input": "<link rel=\"stylesheet\" href=\"http://ha.ckers.org/xss.css\" />",
-    "output": "&lt;link rel=\"stylesheet\" href=\"http://ha.ckers.org/xss.css\"&gt;",
-    "rexml": "&lt;link href=\"http://ha.ckers.org/xss.css\" rel=\"stylesheet\"/&gt;"
+    "output": "&lt;link rel=\"stylesheet\" href=\"http://ha.ckers.org/xss.css\"&gt;"
   },
 
   {
@@ -145,8 +157,8 @@
   {
     "name": "no_closing_script_tags",
     "input": "<script src=http://ha.ckers.org/xss.js?<b>",
-    "output": "&lt;script src=\"http://ha.ckers.org/xss.js?&amp;lt;b\"&gt;&lt;/script&gt;",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "&lt;script src=\"http://ha.ckers.org/xss.js?&amp;lt;b\"&gt;&lt;/script&gt;",
+    "libgumbo": "&lt;script src='http://ha.ckers.org/xss.js?&lt;b'&gt;&lt;/script&gt;"
   },
 
   {
@@ -166,8 +178,8 @@
   {
     "name": "non_alpha_non_digit_3",
     "input": "<img/src=\"http://ha.ckers.org/xss.js\"/>",
-    "output": "<img>",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "<img>",
+    "libgumbo": "<img src='http://ha.ckers.org/xss.js'>" /* see "should_allow_image_src_attribute" test */
   },
 
   {
@@ -365,8 +377,14 @@
   {
     "name": "should_sanitize_half_open_scripts",
     "input": "<img src=\"javascript:alert('XSS')\"",
-    "output": "<img>",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "<img>",
+    "libgumbo": "" /* indeed it is empty */
+  },
+
+  {
+    "name": "should_sanitize_half_open_scripts 2",
+    "input": "<div><img src=\"javascript:alert('XSS')\" </div>",
+    "output": "<div><img></div>"
   },
 
   {
@@ -385,24 +403,30 @@
   },
 
   {
-    "name": "should_sanitize_script_tag_with_multiple_open_brackets_2",
+    "name": "should_sanitize_script_tag_with_multiple_open_brackets_2a",
     "input": "<iframe src=http://ha.ckers.org/scriptlet.html\n<",
-    "output": "&lt;iframe src=\"http://ha.ckers.org/scriptlet.html\"&gt;&lt;/iframe&gt;",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "&lt;iframe src=\"http://ha.ckers.org/scriptlet.html\"&gt;&lt;/iframe&gt;",
+    "libgumbo": "" /* it is indeed empty, see next test */
+  },
+
+  {
+    "name": "should_sanitize_script_tag_with_multiple_open_brackets_2b",
+    "input": "<div><iframe src=http://ha.ckers.org/scriptlet.html\n< </div>",
+    "libxml": "<div>&lt;iframe src=\"http://ha.ckers.org/scriptlet.html\"&gt;&lt;/iframe&gt;</div>"
   },
 
   {
     "name": "should_sanitize_tag_broken_up_by_null",
     "input": "<scr\u0000ipt>alert(\"XSS\")</scr\u0000ipt>",
-    "output": "&lt;scr&gt;&lt;/scr&gt;",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "&lt;scr&gt;&lt;/scr&gt;",
+    "libgumbo": "&lt;scr�ipt&gt;alert('XSS')&lt;/scr�ipt&gt;"
   },
 
   {
     "name": "should_sanitize_unclosed_script",
     "input": "<script src=http://ha.ckers.org/xss.js?<b>",
-    "output": "&lt;script src=\"http://ha.ckers.org/xss.js?&amp;lt;b\"&gt;&lt;/script&gt;",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "&lt;script src=\"http://ha.ckers.org/xss.js?&amp;lt;b\"&gt;&lt;/script&gt;",
+    "libgumbo": "&lt;script src='http://ha.ckers.org/xss.js?&lt;b'&gt;&lt;/script&gt;"
   },
 
   {
@@ -446,8 +470,8 @@
   {
     "name": "quotes_in_attributes",
     "input": "<img src='foo' title='\"foo\" bar' />",
-    "rexml": "<img src='foo' title='\"foo\" bar' />",
-    "output": "<img src='foo' title='\"foo\" bar'>"
+    "libxml": "<img src='foo' title='\"foo\" bar'>",
+    "libgumbo": "<img src='foo' title='&quot;foo&quot; bar'>"
   },
 
   {
@@ -485,8 +509,8 @@
   {
     "name": "allow_html5_image_tag",
     "input": "<image src='foo' />",
-    "rexml": "&lt;image src=\"foo\"&gt;&lt;/image&gt;",
-    "output": "&lt;image src=\"foo\"/&gt;"
+    "libxml": "&lt;image src=\"foo\"&gt;&lt;/image&gt;",
+    "libgumbo": "<img src='foo'>"
   },
 
   {

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,9 +9,14 @@ require File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "loofah"
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "loofah", "helpers"))
 
 puts "=> testing with Nokogiri #{Nokogiri::VERSION_INFO.inspect}"
+puts "=> parser module is #{::Loofah::parser_module}"
 
 class Loofah::TestCase < MiniTest::Spec
   class << self
     alias_method :context, :describe
+  end
+
+  def html5_mode?
+    ::Loofah.html5_mode?
   end
 end

--- a/test/html5/test_sanitizer.rb
+++ b/test/html5/test_sanitizer.rb
@@ -17,18 +17,16 @@ class Html5TestSanitizer < Loofah::TestCase
     Loofah.fragment(stream).scrub!(:escape).to_html
   end
 
-  def check_sanitization(input, htmloutput, xhtmloutput, rexmloutput)
-    ##  libxml uses double-quotes, so let's swappo-boppo our quotes before comparing.
-    sane = sanitize_html(input).gsub('"', "'")
-    htmloutput = htmloutput.gsub('"', "'")
-    xhtmloutput = xhtmloutput.gsub('"', "'")
-    rexmloutput = rexmloutput.gsub('"', "'")
+  def check_sanitization(input, *possible_answers)
+    # shotgun approach - if any of the possible answers match, we win
 
-    ##  HTML5's parsers are shit. there's so much inconsistency with what has closing tags, etc, that
-    ##  it would require a lot of manual hacking to make the tests match libxml's output.
-    ##  instead, I'm taking the shotgun approach, and trying to match any of the described outputs.
-    assert((htmloutput == sane) || (rexmloutput == sane) || (xhtmloutput == sane),
-           %Q{given:    "#{input}"\nexpected: "#{htmloutput}"\ngot:      "#{sane}"})
+    # libxml uses double-quotes, so let's swappo-boppo our quotes before comparing.
+    sane = sanitize_html(input).gsub('"', "'")
+    possible_output = possible_answers.compact.map do |possible_answer|
+      possible_answer.gsub('"', "'")
+    end
+
+    assert_includes(possible_output, sane)
   end
 
   def assert_completes_in_reasonable_time(&block)
@@ -81,7 +79,7 @@ class Html5TestSanitizer < Loofah::TestCase
   #   define_method "test_should_forbid_#{tag_name.upcase}_tag" do
   #     input = "<#{tag_name.upcase} title='1'>foo <bad>bar</bad> baz</#{tag_name.upcase}>"
   #     output = "&lt;#{tag_name.upcase} title=\"1\"&gt;foo &lt;bad&gt;bar&lt;/bad&gt; baz&lt;/#{tag_name.upcase}&gt;"
-  #     check_sanitization(input, output, output, output)
+  #     check_sanitization(input, output)
   #   end
   # end
 
@@ -104,14 +102,14 @@ class Html5TestSanitizer < Loofah::TestCase
     input = "<p data-foo='foo'>foo <bad>bar</bad> baz</p>"
     output = "<p data-foo='foo'>foo &lt;bad&gt;bar&lt;/bad&gt; baz</p>"
 
-    check_sanitization(input, output, output, output)
+    check_sanitization(input, output)
   end
 
   def test_should_allow_multi_word_data_attributes
     input = "<p data-foo-bar-id='11'>foo <bad>bar</bad> baz</p>"
     output = "<p data-foo-bar-id='11'>foo &lt;bad&gt;bar&lt;/bad&gt; baz</p>"
 
-    check_sanitization(input, output, output, output)
+    check_sanitization(input, output)
   end
 
   def test_should_allow_empty_data_attributes
@@ -125,7 +123,7 @@ class Html5TestSanitizer < Loofah::TestCase
     input = '<p contenteditable="false">Hi!</p>'
     output = '<p contenteditable="false">Hi!</p>'
 
-    check_sanitization(input, output, output, output)
+    check_sanitization(input, output)
   end
 
   ##
@@ -135,7 +133,7 @@ class Html5TestSanitizer < Loofah::TestCase
   #   define_method "test_should_forbid_#{attribute_name.upcase}_attribute" do
   #     input = "<p #{attribute_name.upcase}='display: none;'>foo <bad>bar</bad> baz</p>"
   #     output =  "<p>foo &lt;bad&gt;bar&lt;/bad&gt; baz</p>"
-  #     check_sanitization(input, output, output, output)
+  #     check_sanitization(input, output)
   #   end
   # end
 
@@ -143,7 +141,7 @@ class Html5TestSanitizer < Loofah::TestCase
     define_method "test_should_allow_#{protocol}_uris" do
       input = %(<a href="#{protocol}">foo</a>)
       output = "<a href='#{protocol}'>foo</a>"
-      check_sanitization(input, output, output, output)
+      check_sanitization(input, output)
     end
   end
 
@@ -151,7 +149,7 @@ class Html5TestSanitizer < Loofah::TestCase
     define_method "test_should_allow_uppercase_#{protocol}_uris" do
       input = %(<a href="#{protocol.upcase}">foo</a>)
       output = "<a href='#{protocol.upcase}'>foo</a>"
-      check_sanitization(input, output, output, output)
+      check_sanitization(input, output)
     end
   end
 
@@ -159,11 +157,11 @@ class Html5TestSanitizer < Loofah::TestCase
     define_method "test_should_allow_data_#{data_uri_type}_uris" do
       input = %(<a href="data:#{data_uri_type}">foo</a>)
       output = "<a href='data:#{data_uri_type}'>foo</a>"
-      check_sanitization(input, output, output, output)
+      check_sanitization(input, output)
 
       input = %(<a href="data:#{data_uri_type};base64,R0lGODlhAQABA">foo</a>)
       output = "<a href='data:#{data_uri_type};base64,R0lGODlhAQABA'>foo</a>"
-      check_sanitization(input, output, output, output)
+      check_sanitization(input, output)
     end
   end
 
@@ -171,22 +169,22 @@ class Html5TestSanitizer < Loofah::TestCase
     define_method "test_should_allow_uppercase_data_#{data_uri_type}_uris" do
       input = %(<a href="DATA:#{data_uri_type.upcase}">foo</a>)
       output = "<a href='DATA:#{data_uri_type.upcase}'>foo</a>"
-      check_sanitization(input, output, output, output)
+      check_sanitization(input, output)
     end
   end
 
   def test_should_disallow_other_uri_mediatypes
     input = %(<a href="data:foo">foo</a>)
     output = "<a>foo</a>"
-    check_sanitization(input, output, output, output)
+    check_sanitization(input, output)
 
     input = %(<a href="data:image/xxx">foo</a>)
     output = "<a>foo</a>"
-    check_sanitization(input, output, output, output)
+    check_sanitization(input, output)
 
     input = %(<a href="data:image/xxx;base64,R0lGODlhAQABA">foo</a>)
     output = "<a>foo</a>"
-    check_sanitization(input, output, output, output)
+    check_sanitization(input, output)
   end
 
   HTML5::SafeList::SVG_ALLOW_LOCAL_HREF.each do |tag_name|
@@ -231,18 +229,18 @@ class Html5TestSanitizer < Loofah::TestCase
   # def test_should_handle_astral_plane_characters
   #   input = "<p>&#x1d4b5; &#x1d538;</p>"
   #   output = "<p>\360\235\222\265 \360\235\224\270</p>"
-  #   check_sanitization(input, output, output, output)
+  #   check_sanitization(input, output)
 
   #   input = "<p><tspan>\360\235\224\270</tspan> a</p>"
   #   output = "<p><tspan>\360\235\224\270</tspan> a</p>"
-  #   check_sanitization(input, output, output, output)
+  #   check_sanitization(input, output)
   # end
 
   # This affects only NS4. Is it worth fixing?
   #  def test_javascript_includes
   #    input = %(<div size="&{alert('XSS')}">foo</div>)
   #    output = "<div>foo</div>"
-  #    check_sanitization(input, output, output, output)
+  #    check_sanitization(input, output)
   #  end
 
   ##
@@ -255,12 +253,12 @@ class Html5TestSanitizer < Loofah::TestCase
   Dir[File.join(File.dirname(__FILE__), "..", "assets", "testdata_sanitizer_tests1.dat")].each do |filename|
     JSON::parse(open(filename).read).each do |test|
       it "testdata sanitizer #{test["name"]}" do
-        check_sanitization(
-          test["input"],
-          test["output"],
-          test["xhtml"] || test["output"],
-          test["rexml"] || test["output"]
-        )
+        test.delete("name")
+        test.delete("commentary")
+        check_args = []
+        check_args << test.delete("input")
+        check_args += test.keys.sort.map { |k| test[k] }
+        check_sanitization(*check_args)
       end
     end
   end
@@ -270,13 +268,13 @@ class Html5TestSanitizer < Loofah::TestCase
     define_method "test_should_allow_uri_refs_in_svg_attribute_#{attr_name}" do
       input = "<rect fill='url(#foo)' />"
       output = "<rect fill='url(#foo)'></rect>"
-      check_sanitization(input, output, output, output)
+      check_sanitization(input, output)
     end
 
     define_method "test_absolute_uri_refs_in_svg_attribute_#{attr_name}" do
       input = "<rect fill='url(http://bad.com/) #fff' />"
       output = "<rect fill='  #fff'></rect>"
-      check_sanitization(input, output, output, output)
+      check_sanitization(input, output)
     end
   end
 

--- a/test/html5/test_sanitizer.rb
+++ b/test/html5/test_sanitizer.rb
@@ -35,34 +35,65 @@ class Html5TestSanitizer < Loofah::TestCase
     assert_in_delta t0, Time.now, 0.1 # arbitrary seconds
   end
 
+  ALLOWED_ELEMENTS_PARENT = {
+    "caption" => "table",
+    "col" => "table",
+    "colgroup" => "table",
+    "li" => "ul",
+    "tbody" => "table",
+    "td" => "table",
+    "tfoot" => "table",
+    "th" => "table",
+    "thead" => "table",
+    "tr" => "table",
+  }
   (HTML5::SafeList::ALLOWED_ELEMENTS).each do |tag_name|
     define_method "test_should_allow_#{tag_name}_tag" do
-      input = "<#{tag_name} title='1'>foo <bad>bar</bad> baz</#{tag_name}>"
-      htmloutput = "<#{tag_name.downcase} title='1'>foo &lt;bad&gt;bar&lt;/bad&gt; baz</#{tag_name.downcase}>"
-      xhtmloutput = "<#{tag_name} title='1'>foo &lt;bad&gt;bar&lt;/bad&gt; baz</#{tag_name}>"
-      rexmloutput = xhtmloutput
-
-      if %w[caption colgroup optgroup option tbody td tfoot th thead tr].include?(tag_name)
-        htmloutput = "foo &lt;bad&gt;bar&lt;/bad&gt; baz"
-        xhtmloutput = htmloutput
-      elsif tag_name == "col"
-        htmloutput = "<col title='1'>foo &lt;bad&gt;bar&lt;/bad&gt; baz"
-        xhtmloutput = htmloutput
-        rexmloutput = "<col title='1' />"
-      elsif tag_name == "table"
-        htmloutput = "foo &lt;bad&gt;bar&lt;/bad&gt;baz<table title='1'> </table>"
-        xhtmloutput = htmloutput
-      elsif tag_name == "image"
-        htmloutput = "<img title='1'/>foo &lt;bad&gt;bar&lt;/bad&gt; baz"
-        xhtmloutput = htmloutput
-        rexmloutput = "<image title='1'>foo &lt;bad&gt;bar&lt;/bad&gt; baz</image>"
-      elsif HTML5::SafeList::VOID_ELEMENTS.include?(tag_name)
-        htmloutput = "<#{tag_name} title='1'>foo &lt;bad&gt;bar&lt;/bad&gt; baz"
-        xhtmloutput = htmloutput
-        htmloutput += "<br/>" if tag_name == "br"
-        rexmloutput = "<#{tag_name} title='1' />"
+      parent = ALLOWED_ELEMENTS_PARENT[tag_name]
+      if parent
+        input = "<#{parent}><#{tag_name} title='1'>foo</#{tag_name}></#{parent}>"
+        naive_output = "<#{parent}><#{tag_name.downcase} title='1'>foo</#{tag_name.downcase}></#{parent}>"
+      else
+        input = "<#{tag_name} title='1'>foo</#{tag_name}>"
+        naive_output = "<#{tag_name.downcase} title='1'>foo</#{tag_name.downcase}>"
       end
-      check_sanitization(input, htmloutput, xhtmloutput, rexmloutput)
+
+      outputs = []
+
+      if html5_mode?
+        # libgumbo
+        case tag_name
+        when "col"
+          outputs << "foo<table><colgroup><col title='1'></colgroup></table>" # libgumbo
+        when "table"
+          outputs << "foo<table title='1'></table>" # libgumbo
+        when "tr"
+          outputs << "foo<table><tbody><tr title='1'></tr></tbody></table>" # libgumbo
+        when "th", "td"
+          outputs << "<table><tbody><tr><#{tag_name} title='1'>foo</#{tag_name}></tr></tbody></table>" # libgumbo
+        when "colgroup", "tbody", "tfoot", "thead"
+          outputs << "foo<table><#{tag_name} title='1'></#{tag_name}></table>" # libgumbo
+        when "br"
+          outputs << "<br title='1'>foo<br>"
+        end
+      else
+        # libxml
+        case tag_name
+        when "col"
+          outputs << "<table>\n<col title='1'>foo</table>" # libxml
+        end
+      end
+
+      if outputs.empty?
+        # common
+        if HTML5::SafeList::VOID_ELEMENTS.include?(tag_name)
+          outputs << "<#{tag_name} title='1'>foo"
+        else
+          outputs << naive_output
+        end
+      end
+
+      check_sanitization(input, *outputs)
     end
   end
 
@@ -88,13 +119,13 @@ class Html5TestSanitizer < Loofah::TestCase
     define_method "test_should_allow_#{attribute_name}_attribute" do
       input = "<p #{attribute_name}='foo'>foo <bad>bar</bad> baz</p>"
       if %w[checked compact disabled ismap multiple nohref noshade nowrap readonly selected].include?(attribute_name)
-        output = "<p #{attribute_name}>foo &lt;bad&gt;bar&lt;/bad&gt; baz</p>"
         htmloutput = "<p #{attribute_name.downcase}>foo &lt;bad&gt;bar&lt;/bad&gt; baz</p>"
+        html5output = "<p #{attribute_name.downcase}='foo'>foo &lt;bad&gt;bar&lt;/bad&gt; baz</p>"
       else
-        output = "<p #{attribute_name}='foo'>foo &lt;bad&gt;bar&lt;/bad&gt; baz</p>"
         htmloutput = "<p #{attribute_name.downcase}='foo'>foo &lt;bad&gt;bar&lt;/bad&gt; baz</p>"
+        html5output = nil
       end
-      check_sanitization(input, htmloutput, output, output)
+      check_sanitization(input, htmloutput, html5output)
     end
   end
 
@@ -115,8 +146,9 @@ class Html5TestSanitizer < Loofah::TestCase
   def test_should_allow_empty_data_attributes
     input = "<p data-foo data-bar="">foo <bad>bar</bad> baz</p>"
     output = "<p data-foo data-bar=''>foo &lt;bad&gt;bar&lt;/bad&gt; baz</p>"
+    html5output = "<p data-foo='' data-bar=''>foo &lt;bad&gt;bar&lt;/bad&gt; baz</p>"
 
-    check_sanitization(input, output, output, output)
+    check_sanitization(input, output, html5output)
   end
 
   def test_should_allow_contenteditable

--- a/test/integration/test_scrubbers.rb
+++ b/test/integration/test_scrubbers.rb
@@ -69,7 +69,11 @@ class IntegrationTestScrubbers < Loofah::TestCase
           doc = Loofah::HTML::Document.parse "<html><body>#{WHITEWASH_FRAGMENT}</body></html>"
           result = doc.scrub! :whitewash
 
-          ww_result = Nokogiri.uses_libxml?("<2.9.11") ? WHITEWASH_RESULT : WHITEWASH_RESULT_LIBXML2911
+          ww_result = if Nokogiri.uses_libxml?("< 2.9.11") || html5_mode?
+            WHITEWASH_RESULT
+          else
+            WHITEWASH_RESULT_LIBXML2911
+          end
           assert_equal ww_result, doc.xpath("/html/body").inner_html
           assert_equal doc, result
         end
@@ -141,7 +145,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
         refute_nil doc.xpath("/html/body").first
 
         string = doc.to_s
-        assert_match %r/<!DOCTYPE/, string
+        assert_match(%r/<!DOCTYPE/, string) unless html5_mode?
         assert_match %r/<html>/, string
         assert_match %r/<head>/, string
         assert_match %r/<body>/, string
@@ -156,7 +160,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
         refute_nil doc.xpath("/html/body").first
 
         string = doc.serialize
-        assert_match %r/<!DOCTYPE/, string
+        assert_match(%r/<!DOCTYPE/, string) unless html5_mode?
         assert_match %r/<html>/, string
         assert_match %r/<head>/, string
         assert_match %r/<body>/, string
@@ -248,7 +252,11 @@ class IntegrationTestScrubbers < Loofah::TestCase
           doc = Loofah::HTML::DocumentFragment.parse "<div>#{WHITEWASH_FRAGMENT}</div>"
           result = doc.scrub! :whitewash
 
-          ww_result = Nokogiri.uses_libxml?("<2.9.11") ? WHITEWASH_RESULT : WHITEWASH_RESULT_LIBXML2911
+          ww_result = if Nokogiri.uses_libxml?("< 2.9.11") || html5_mode?
+            WHITEWASH_RESULT
+          else
+            WHITEWASH_RESULT_LIBXML2911
+          end
           assert_equal ww_result, doc.xpath("./div").inner_html
           assert_equal doc, result
         end


### PR DESCRIPTION
The libgumbo parser used by Nokogiri::HTML5 is superior to the libxml2 parser used by Nokogiri::HTML4 (the default).

This is a draft pull request to see how hard it would be to default to use that parser for Loofah's sanitization, and evaluate what changes might be breaking to the many Rails apps that use it.

Note that Loofah can only support HTML5 in Nokogiri >= 1.14.0 because it requires the subclassing fix at https://github.com/sparklemotion/nokogiri/commit/ebde7dae770aaefa667ee02ac57a2c0bfed1164c

See a related but orthogonal issue to default Nokogiri to HTML5: https://github.com/sparklemotion/nokogiri/issues/2331

- [x] run against some large Rails apps in CI
- [ ] generate some performance benchmark results
- [ ] write a nice changelog entry detailing the known behavior changes that might trip people up, and how to set the environment variable to escape back to the old behavior in a pinch
- [ ] run a CI job against an older Nokogiri version to make sure we keep backwards compatibility
- [ ] blocked on a Nokogiri v1.14.0 release
