### PR TITLE
ci: ensure a min rubygems version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,5 @@ jobs:
         with:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true
+          rubygems: latest
       - run: bundle exec rake test


### PR DESCRIPTION
to prevent the psych issue with older versions (ruby 2.5)
