### PR TITLE
dep: remove dependency on RR for mocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
         with:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true
-          rubygems: latest
       - run: bundle exec rake test
 
   # borrowed from nokogiri/.github/workflows/downstream.yml

--- a/loofah.gemspec
+++ b/loofah.gemspec
@@ -39,6 +39,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("minitest", ["~> 5.14"])
   spec.add_development_dependency("rake", ["~> 13.0"])
   spec.add_development_dependency("rdoc", [">= 4.0", "< 7"])
-  spec.add_development_dependency("rr", ["~> 1.2.0"])
   spec.add_development_dependency("rubocop", "~> 1.1")
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,12 +1,9 @@
 require "minitest/autorun"
 require "minitest/unit"
 require "minitest/spec"
-require "rr"
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "loofah"))
-
-# require the ActionView helpers here, since they are no longer required automatically
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "loofah", "helpers"))
+require_relative "../lib/loofah"
+require_relative "../lib/loofah/helpers"
 
 puts "=> testing with Nokogiri #{Nokogiri::VERSION_INFO.inspect}"
 

--- a/test/integration/test_scrubbers.rb
+++ b/test/integration/test_scrubbers.rb
@@ -97,12 +97,14 @@ class IntegrationTestScrubbers < Loofah::TestCase
     end
 
     context "#scrub_document" do
-      it "be a shortcut for parse-and-scrub" do
-        mock_doc = Object.new
-        mock(Loofah).document(:string_or_io) { mock_doc }
-        mock(mock_doc).scrub!(:method)
+      it "is a shortcut for parse-and-scrub" do
+        mock_doc = MiniTest::Mock.new
+        mock_doc.expect(:scrub!, "sanitized_string", [:method])
+        Loofah.stub(:document, mock_doc) do
+          Loofah.scrub_document("string", :method)
+        end
 
-        Loofah.scrub_document(:string_or_io, :method)
+        mock_doc.verify
       end
     end
 
@@ -310,12 +312,14 @@ class IntegrationTestScrubbers < Loofah::TestCase
     end
 
     context "#scrub_fragment" do
-      it "be a shortcut for parse-and-scrub" do
-        mock_doc = Object.new
-        mock(Loofah).fragment(:string_or_io) { mock_doc }
-        mock(mock_doc).scrub!(:method)
+      it "is a shortcut for parse-and-scrub" do
+        mock_doc = MiniTest::Mock.new
+        mock_doc.expect(:scrub!, "sanitized_string", [:method])
+        Loofah.stub(:fragment, mock_doc) do
+          Loofah.scrub_fragment("string", :method)
+        end
 
-        Loofah.scrub_fragment(:string_or_io, :method)
+        mock_doc.verify
       end
     end
 

--- a/test/unit/test_helpers.rb
+++ b/test/unit/test_helpers.rb
@@ -6,54 +6,73 @@ class UnitTestHelpers < Loofah::TestCase
   describe "Helpers" do
     context ".strip_tags" do
       it "invoke Loofah.fragment.text" do
-        mock_doc = Object.new
-        mock(Loofah).fragment(HTML_STRING) { mock_doc }
-        mock(mock_doc).text
+        mock_doc = MiniTest::Mock.new
+        mock_doc.expect(:text, "string_value", [])
+        Loofah.stub(:fragment, mock_doc) do
+          Loofah::Helpers.strip_tags(HTML_STRING)
+        end
 
-        Loofah::Helpers.strip_tags HTML_STRING
+        mock_doc.verify
       end
     end
 
     context ".sanitize" do
       it "invoke Loofah.scrub_fragment(:strip).to_s" do
-        mock_doc = Object.new
-        mock_node = Object.new
-        mock(Loofah).fragment(HTML_STRING) { mock_doc }
-        mock(mock_doc).scrub!(:strip) { mock_doc }
-        mock(mock_doc).xpath("./form") { [mock_node] }
-        mock(mock_node).remove
-        mock(mock_doc).to_s
+        mock_doc = MiniTest::Mock.new
+        mock_doc.expect(:scrub!, mock_doc, [:strip])
+        mock_doc.expect(:xpath, [], ["./form"])
+        mock_doc.expect(:to_s, "string_value", [])
 
-        Loofah::Helpers.sanitize HTML_STRING
+        Loofah.stub(:fragment, mock_doc) do
+          Loofah::Helpers.sanitize(HTML_STRING)
+        end
+
+        mock_doc.verify
       end
     end
 
     context ".sanitize_css" do
       it "invokes HTML5lib's css scrubber" do
-        mock(Loofah::HTML5::Scrub).scrub_css("foobar")
-        Loofah::Helpers.sanitize_css("foobar")
+        actual = nil
+        Loofah::HTML5::Scrub.stub(:scrub_css, "scrubbed", ["foobar"]) do
+          actual = Loofah::Helpers.sanitize_css("foobar")
+        end
+
+        assert_equal("scrubbed", actual)
       end
     end
 
     describe "ActionView" do
       describe "FullSanitizer#sanitize" do
         it "calls .strip_tags" do
-          mock(Loofah::Helpers).strip_tags("foobar")
-          Loofah::Helpers::ActionView::FullSanitizer.new.sanitize "foobar"
+          actual = nil
+          Loofah::Helpers.stub(:strip_tags, "stripped", ["foobar"]) do
+            actual = Loofah::Helpers::ActionView::FullSanitizer.new.sanitize("foobar")
+          end
+
+          assert_equal("stripped", actual)
         end
       end
 
       describe "SafeListSanitizer#sanitize" do
         it "calls .sanitize" do
-          mock(Loofah::Helpers).sanitize("foobar")
-          Loofah::Helpers::ActionView::SafeListSanitizer.new.sanitize "foobar"
+          actual = nil
+          Loofah::Helpers.stub(:sanitize, "sanitized", ["foobar"]) do
+            actual = Loofah::Helpers::ActionView::SafeListSanitizer.new.sanitize("foobar")
+          end
+
+          assert_equal("sanitized", actual)
         end
       end
 
       describe "SafeListSanitizer#sanitize_css" do
         it "calls .sanitize_css" do
-          mock(Loofah::Helpers).sanitize_css("foobar")
-          Loofah::Helpers::ActionView::SafeListSanitizer.new.sanitize_css "foobar"
+          actual = nil
+          Loofah::Helpers.stub(:sanitize_css, "sanitized", ["foobar"]) do
+            actual = Loofah::Helpers::ActionView::SafeListSanitizer.new.sanitize_css "foobar"
+          end
+
+          assert_equal("sanitized", actual)
         end
       end
     end


### PR DESCRIPTION
Let's just use MiniTest::Mock or MiniTest's stubbing.
