### PR TITLE
add html5 support, get jruby green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "head", "truffleruby-head"]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "head", "truffleruby-head", "jruby-9.4", "jruby-head"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
           rubygems: latest
       - run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,34 @@
 
 ## next / unreleased
 
-### Notable Change: `Loofah::HTML4` module and namespace
+### HTML5 Support
 
-`Loofah::HTML` has been renamed to `Loofah::HTML4`, and `Loofah::HTML` is aliased to preserve backwards-compatibility. `Nokogiri::HTML` and `Nokogiri::HTML4` parse methods still use libxml2's (or NekoHTML's) HTML4 parser in the v1.12 release series.
+Classes `Loofah::HTML5::Document` and `Loofah::HTML5::DocumentFragment` are introduced, along with helper methods:
+
+- `Loofah.html5_document`
+- `Loofah.html5_fragment`
+- `Loofah.scrub_html5_document`
+- `Loofah.scrub_html5_fragment`
+
+These classes and methods use Nokogiri's HTML5 parser to ensure modern web standards are used.
+
+⚠ HTML5 functionality is only available with Nokogiri v1.14.0 and higher.
+
+⚠ HTML5 functionality is not available for JRuby. Please see [this upstream Nokogiri issue](https://github.com/sparklemotion/nokogiri/issues/2227) if you're interested in helping implement and support HTML5 support.
+
+
+### `Loofah::HTML4` module and namespace
+
+`Loofah::HTML` has been renamed to `Loofah::HTML4`, and `Loofah::HTML` is aliased to preserve backwards-compatibility. `Nokogiri::HTML` and `Nokogiri::HTML4` parse methods still use libxml2's (or NekoHTML's) HTML4 parser.
 
 Take special note that if you rely on the class name of an object in your code, objects will now report a class of `Loofah::HTML4::Foo` where they previously reported `Loofah::HTML::Foo`. Instead of relying on the string returned by `Object#class`, prefer `Class#===` or `Object#is_a?` or `Object#instance_of?`.
 
-Future releases of Nokogiri may deprecate `HTML` methods or otherwise change this behavior, so please start using `HTML4` in place of `HTML`.
+Future releases of Nokogiri may deprecate `HTML` classes and methods or otherwise change this behavior, so please start using `HTML4` in place of `HTML`.
+
+
+### Official support for JRuby
+
+This version introduces official support for JRuby. Previously, the test suite had never been green due to differences in behavior in the underlying HTML parser used by Nokogiri. We've updated the test suite to accommodate those differences, and have added JRuby to the CI suite.
 
 
 ## 2.20.0 / 2023-04-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## next / unreleased
+
+### Notable Change: `Loofah::HTML4` module and namespace
+
+`Loofah::HTML` has been renamed to `Loofah::HTML4`, and `Loofah::HTML` is aliased to preserve backwards-compatibility. `Nokogiri::HTML` and `Nokogiri::HTML4` parse methods still use libxml2's (or NekoHTML's) HTML4 parser in the v1.12 release series.
+
+Take special note that if you rely on the class name of an object in your code, objects will now report a class of `Loofah::HTML4::Foo` where they previously reported `Loofah::HTML::Foo`. Instead of relying on the string returned by `Object#class`, prefer `Class#===` or `Object#is_a?` or `Object#instance_of?`.
+
+Future releases of Nokogiri may deprecate `HTML` methods or otherwise change this behavior, so please start using `HTML4` in place of `HTML`.
+
+
 ## 2.20.0 / 2023-04-01
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -95,15 +95,16 @@ Generally speaking, unless you expect to have a DOCTYPE and a single root node, 
 
 ### Side Note: HTML4 vs HTML5
 
-Currently, Loofah's methods `Loofah.document` and `Loofah.fragment` are aliases to `.html4_document` and `.html4_fragment`, which use Nokogiri's HTML4 parser. Similarly, `Loofah::HTML::Document` and `Loofah::HTML::DocumentFragment` are aliased to `Loofah::HTML4::Document` and `Loofah::HTML4::DocumentFragment`.
+⚠ _HTML5 functionality is not available on JRuby, or with versions of Nokogiri `< 1.14.0`._
 
-**Please note** that in a future version of Loofah, these methods and classes will switch to using Nokogiri's HTML5 parser and classes on platforms that support it [1].
+Currently, Loofah's methods `Loofah.document` and `Loofah.fragment` are aliases to `.html4_document` and `.html4_fragment`, which use Nokogiri's HTML4 parser. (Similarly, `Loofah::HTML::Document` and `Loofah::HTML::DocumentFragment` are aliased to `Loofah::HTML4::Document` and `Loofah::HTML4::DocumentFragment`.)
 
-If you are sure that you need to use the HTML4 parser, you should explicitly call `.html4_document` or `.html4_fragment` to avoid breakage in a future version.
+**Please note** that in a future version of Loofah, these methods and classes may switch to using Nokogiri's HTML5 parser and classes on platforms that support it [1].
 
-**We strongly recommend that you explicitly use `.html5_document` or `.html5_fragment`** unless you know of a compelling reason not to.
+**We strongly recommend that you explicitly use `.html5_document` or `.html5_fragment`** unless you know of a compelling reason not to. If you are sure that you need to use the HTML4 parser, you should explicitly call `.html4_document` or `.html4_fragment` to avoid breakage in a future version.
 
   [1]: [[feature request] HTML5 parser for JRuby implementation · Issue #2227 · sparklemotion/nokogiri](https://github.com/sparklemotion/nokogiri/issues/2227)
+
 
 ### `Loofah::HTML5::Document` and `Loofah::HTML5::DocumentFragment`
 

--- a/README.md
+++ b/README.md
@@ -14,59 +14,61 @@
 
 Loofah is a general library for manipulating and transforming HTML/XML documents and fragments, built on top of Nokogiri.
 
-Loofah excels at HTML sanitization (XSS prevention). It includes some nice HTML sanitizers, which are based on HTML5lib's safelist, so it most likely won't make your codes less secure. (These statements have not been evaluated by Netexperts.)
+Loofah also includes some HTML sanitizers based on `html5lib`'s safelist, which are a specific application of the general transformation functionality.
 
-ActiveRecord extensions for sanitization are available in the [`loofah-activerecord` gem](https://github.com/flavorjones/loofah-activerecord).
+Active Record extensions for HTML sanitization are available in the [`loofah-activerecord` gem](https://github.com/flavorjones/loofah-activerecord).
 
 
 ## Features
 
-* Easily write custom scrubbers for HTML/XML leveraging the sweetness of Nokogiri (and HTML5lib's safelists).
-* Common HTML sanitizing tasks are built-in:
+* Easily write custom transformations for HTML and XML
+* Common HTML sanitizing transformations are built-in:
   * _Strip_ unsafe tags, leaving behind only the inner text.
   * _Prune_ unsafe tags and their subtrees, removing all traces that they ever existed.
   * _Escape_ unsafe tags and their subtrees, leaving behind lots of <tt>&lt;</tt> and <tt>&gt;</tt> entities.
   * _Whitewash_ the markup, removing all attributes and namespaced nodes.
-* Common HTML transformation tasks are built-in:
+* Other common HTML transformations are built-in:
   * Add the _nofollow_ attribute to all hyperlinks.
-* Format markup as plain text, with or without sensible whitespace handling around block elements.
+  * Remove _unprintable_ characters from text nodes.
+* Format markup as plain text, with (or without) sensible whitespace handling around block elements.
 * Replace Rails's `strip_tags` and `sanitize` view helper methods.
 
 
 ## Compare and Contrast
 
-Loofah is one of two known Ruby XSS/sanitization solutions that
-guarantees well-formed and valid markup (the other is Sanitize, which
-also uses Nokogiri).
+Loofah is both:
 
-Loofah works on XML, XHTML and HTML documents.
+- a general framework for transforming XML, XHTML, and HTML documents
+- a specific toolkit for HTML sanitization
 
-Also, it's pretty fast. Here is a benchmark comparing Loofah to other
-commonly-used libraries (ActionView, Sanitize, HTML5lib and HTMLfilter):
+### General document transformation
 
-* https://gist.github.com/170193
+Loofah tries to make it easy to write your own custom scrubbers for whatever document transformation you need. You don't like the built-in scrubbers? Build your own, like a boss.
 
-Lastly, Loofah is extensible. It's super-easy to write your own custom
-scrubbers for whatever document manipulation you need. You don't like
-the built-in scrubbers? Build your own, like a boss.
+
+### HTML sanitization
+
+Another Ruby library that provides HTML sanitization is [`rgrove/sanitize`](https://github.com/rgrove/sanitize), another library built on top of Nokogiri, which provides a bit more flexibility on the tags and attributes being scrubbed.
+
+You may also want to look at [`rails/rails-html-sanitizer`](https://github.com/rails/rails-html-sanitizer) which is built on top of Loofah and provides some useful extensions and additional flexibility in the HTML sanitization.
 
 
 ## The Basics
 
-Loofah wraps [Nokogiri](http://nokogiri.org) in a loving
-embrace. Nokogiri is an excellent HTML/XML parser. If you don't know
-how Nokogiri works, you might want to pause for a moment and go check
-it out. I'll wait.
+Loofah wraps [Nokogiri](http://nokogiri.org) in a loving embrace. Nokogiri is a stable, well-maintained parser for XML, HTML4, and HTML5.
 
-Loofah presents the following classes:
+Loofah implements the following classes:
 
-* `Loofah::HTML::Document` and `Loofah::HTML::DocumentFragment`
-* `Loofah::XML::Document` and `Loofah::XML::DocumentFragment`
-* `Loofah::Scrubber`
+* `Loofah::HTML5::Document`
+* `Loofah::HTML5::DocumentFragment`
+* `Loofah::HTML4::Document` (aliased as `Loofah::HTML::Document` for now)
+* `Loofah::HTML4::DocumentFragment` (aliased as `Loofah::HTML::DocumentFragment` for now)
+* `Loofah::XML::Document`
+* `Loofah::XML::DocumentFragment`
 
-The documents and fragments are subclasses of the similar Nokogiri classes.
+These document and fragment classes are subclasses of the similarly-named Nokogiri classes `Nokogiri::HTML5::Document` et al.
 
-The Scrubber represents the document manipulation, either by wrapping
+Loofah also implements `Loofah::Scrubber`, which represents the document transformation, either by wrapping
 a block,
 
 ``` ruby
@@ -80,50 +82,48 @@ or by implementing a method.
 
 ### Side Note: Fragments vs Documents
 
-Generally speaking, unless you expect to have a DOCTYPE and a single
-root node, you don't have a *document*, you have a *fragment*. For
-HTML, another rule of thumb is that *documents* have `html` and `body`
-tags, and *fragments* usually do not.
+Generally speaking, unless you expect to have a DOCTYPE and a single root node, you don't have a *document*, you have a *fragment*. For HTML, another rule of thumb is that *documents* have `html` and `body` tags, and *fragments* usually do not.
 
-HTML fragments should be parsed with Loofah.fragment. The result won't
-be wrapped in `html` or `body` tags, won't have a DOCTYPE declaration,
-`head` elements will be silently ignored, and multiple root nodes are
-allowed.
+**HTML fragments** should be parsed with `Loofah.html5_fragment` or `Loofah.html4_fragment`. The result won't be wrapped in `html` or `body` tags, won't have a DOCTYPE declaration, `head` elements will be silently ignored, and multiple root nodes are allowed.
 
-XML fragments should be parsed with Loofah.xml_fragment. The result
-won't have a DOCTYPE declaration, and multiple root nodes are allowed.
+**HTML documents** should be parsed with `Loofah.html5_document` or `Loofah.html4_document`. The result will have a DOCTYPE declaration, along with `html`, `head` and `body` tags.
 
-HTML documents should be parsed with Loofah.document. The result will
-have a DOCTYPE declaration, along with `html`, `head` and `body` tags.
+**XML fragments** should be parsed with `Loofah.xml_fragment`. The result won't have a DOCTYPE declaration, and multiple root nodes are allowed.
 
-XML documents should be parsed with Loofah.xml_document. The result
-will have a DOCTYPE declaration and a single root node.
+**XML documents** should be parsed with `Loofah.xml_document`. The result will have a DOCTYPE declaration and a single root node.
 
 
-### Loofah::HTML::Document and Loofah::HTML::DocumentFragment
+### Side Note: HTML4 vs HTML5
 
-These classes are subclasses of Nokogiri::HTML::Document and
-Nokogiri::HTML::DocumentFragment, so you get all the markup
-fixer-uppery and API goodness of Nokogiri.
+Currently, Loofah's methods `Loofah.document` and `Loofah.fragment` are aliases to `.html4_document` and `.html4_fragment`, which use Nokogiri's HTML4 parser. Similarly, `Loofah::HTML::Document` and `Loofah::HTML::DocumentFragment` are aliased to `Loofah::HTML4::Document` and `Loofah::HTML4::DocumentFragment`.
 
-The module methods Loofah.document and Loofah.fragment will parse an
-HTML document and an HTML fragment, respectively.
+**Please note** that in a future version of Loofah, these methods and classes will switch to using Nokogiri's HTML5 parser and classes on platforms that support it [1].
+
+If you are sure that you need to use the HTML4 parser, you should explicitly call `.html4_document` or `.html4_fragment` to avoid breakage in a future version.
+
+**We strongly recommend that you explicitly use `.html5_document` or `.html5_fragment`** unless you know of a compelling reason not to.
+
+  [1]: [[feature request] HTML5 parser for JRuby implementation · Issue #2227 · sparklemotion/nokogiri](https://github.com/sparklemotion/nokogiri/issues/2227)
+
+### `Loofah::HTML5::Document` and `Loofah::HTML5::DocumentFragment`
+
+These classes are subclasses of `Nokogiri::HTML5::Document` and `Nokogiri::HTML5::DocumentFragment`.
+
+The module methods `Loofah.html5_document` and `Loofah.html5_fragment` will parse either an HTML document and an HTML fragment, respectively.
 
 ``` ruby
-Loofah.document(unsafe_html).is_a?(Nokogiri::HTML::Document)         # => true
-Loofah.fragment(unsafe_html).is_a?(Nokogiri::HTML::DocumentFragment) # => true
+Loofah.html5_document(unsafe_html).is_a?(Nokogiri::HTML5::Document)         # => true
+Loofah.html5_fragment(unsafe_html).is_a?(Nokogiri::HTML5::DocumentFragment) # => true
 ```
 
-Loofah injects a `scrub!` method, which takes either a symbol (for
-built-in scrubbers) or a Loofah::Scrubber object (for custom
-scrubbers), and modifies the document in-place.
+Loofah injects a `scrub!` method, which takes either a symbol (for built-in scrubbers) or a `Loofah::Scrubber` object (for custom scrubbers), and modifies the document in-place.
 
 Loofah overrides `to_s` to return HTML:
 
 ``` ruby
 unsafe_html = "ohai! <div>div is safe</div> <script>but script is not</script>"
 
-doc = Loofah.fragment(unsafe_html).scrub!(:prune)
+doc = Loofah.html5_fragment(unsafe_html).scrub!(:prune)
 doc.to_s    # => "ohai! <div>div is safe</div> "
 ```
 
@@ -136,32 +136,38 @@ doc.text    # => "ohai! div is safe "
 Also, `to_text` is available, which does the right thing with whitespace around block-level and line break elements.
 
 ``` ruby
-doc = Loofah.fragment("<h1>Title</h1><div>Content<br>Next line</div>")
+doc = Loofah.html5_fragment("<h1>Title</h1><div>Content<br>Next line</div>")
 doc.text    # => "TitleContentNext line"            # probably not what you want
 doc.to_text # => "\nTitle\n\nContent\nNext line\n"  # better
 ```
 
-### Loofah::XML::Document and Loofah::XML::DocumentFragment
+### `Loofah::HTML4::Document` and `Loofah::HTML4::DocumentFragment`
 
-These classes are subclasses of Nokogiri::XML::Document and
-Nokogiri::XML::DocumentFragment, so you get all the markup
-fixer-uppery and API goodness of Nokogiri.
+These classes are subclasses of `Nokogiri::HTML4::Document` and `Nokogiri::HTML4::DocumentFragment`.
 
-The module methods Loofah.xml_document and Loofah.xml_fragment will
-parse an XML document and an XML fragment, respectively.
+The module methods `Loofah.html4_document` and `Loofah.html4_fragment` will parse either an HTML document and an HTML fragment, respectively.
+
+``` ruby
+Loofah.html4_document(unsafe_html).is_a?(Nokogiri::HTML4::Document)         # => true
+Loofah.html4_fragment(unsafe_html).is_a?(Nokogiri::HTML4::DocumentFragment) # => true
+```
+
+### `Loofah::XML::Document` and `Loofah::XML::DocumentFragment`
+
+These classes are subclasses of `Nokogiri::XML::Document` and `Nokogiri::XML::DocumentFragment`.
+
+The module methods `Loofah.xml_document` and `Loofah.xml_fragment` will parse an XML document and an XML fragment, respectively.
 
 ``` ruby
 Loofah.xml_document(bad_xml).is_a?(Nokogiri::XML::Document)         # => true
 Loofah.xml_fragment(bad_xml).is_a?(Nokogiri::XML::DocumentFragment) # => true
 ```
 
-### Nodes and NodeSets
+### Nodes and Node Sets
 
-Nokogiri::XML::Node and Nokogiri::XML::NodeSet also get a `scrub!`
-method, which makes it easy to scrub subtrees.
+Nokogiri's `Node` and `NodeSet` classes also get a `scrub!` method, which makes it easy to scrub subtrees.
 
-The following code will apply the `employee_scrubber` only to the
-`employee` nodes (and their subtrees) in the document:
+The following code will apply the `employee_scrubber` only to the `employee` nodes (and their subtrees) in the document:
 
 ``` ruby
 Loofah.xml_document(bad_xml).xpath("//employee").scrub!(employee_scrubber)
@@ -173,7 +179,7 @@ And this code will only scrub the first `employee` node and its subtree:
 Loofah.xml_document(bad_xml).at_xpath("//employee").scrub!(employee_scrubber)
 ```
 
-### Loofah::Scrubber
+### `Loofah::Scrubber`
 
 A Scrubber wraps up a block (or method) that is run on a document node:
 
@@ -187,14 +193,11 @@ end
 This can then be run on a document:
 
 ``` ruby
-Loofah.fragment("<span>foo</span><p>bar</p>").scrub!(span2div).to_s
+Loofah.html5_fragment("<span>foo</span><p>bar</p>").scrub!(span2div).to_s
 # => "<div>foo</div><p>bar</p>"
 ```
 
-Scrubbers can be run on a document in either a top-down traversal (the
-default) or bottom-up. Top-down scrubbers can optionally return
-Scrubber::STOP to terminate the traversal of a subtree. Read below and
-in the Loofah::Scrubber class for more detailed usage.
+Scrubbers can be run on a document in either a top-down traversal (the default) or bottom-up. Top-down scrubbers can optionally return `Scrubber::STOP` to terminate the traversal of a subtree. Read below and in the `Loofah::Scrubber` class for more detailed usage.
 
 Here's an XML example:
 
@@ -211,10 +214,10 @@ Loofah.xml_document(File.read('plague.xml')).scrub!(bring_out_your_dead)
 
 ### Built-In HTML Scrubbers
 
-Loofah comes with a set of sanitizing scrubbers that use HTML5lib's
-safelist algorithm:
+Loofah comes with a set of sanitizing scrubbers that use `html5lib`'s safelist algorithm:
 
 ``` ruby
+doc = Loofah.html5_document(input)
 doc.scrub!(:strip)       # replaces unknown/unsafe tags with their inner text
 doc.scrub!(:prune)       #  removes unknown/unsafe tags and their children
 doc.scrub!(:escape)      #  escapes unknown/unsafe tags, like this: &lt;script&gt;
@@ -222,14 +225,14 @@ doc.scrub!(:whitewash)   #  removes unknown/unsafe/namespaced tags and their chi
                          #          and strips all node attributes
 ```
 
-Loofah also comes with some common transformation tasks: 
+Loofah also comes with some common transformation tasks:
 
 ``` ruby
 doc.scrub!(:nofollow)    #     adds rel="nofollow" attribute to links
 doc.scrub!(:unprintable) #  removes unprintable characters from text nodes
 ```
 
-See Loofah::Scrubbers for more details and example usage.
+See `Loofah::Scrubbers` for more details and example usage.
 
 
 ### Chaining Scrubbers
@@ -237,7 +240,7 @@ See Loofah::Scrubbers for more details and example usage.
 You can chain scrubbers:
 
 ``` ruby
-Loofah.fragment("<span>hello</span> <script>alert('OHAI')</script>") \
+Loofah.html5_fragment("<span>hello</span> <script>alert('OHAI')</script>") \
       .scrub!(:prune) \
       .scrub!(span2div).to_s
 # => "<div>hello</div> "
@@ -245,21 +248,26 @@ Loofah.fragment("<span>hello</span> <script>alert('OHAI')</script>") \
 
 ### Shorthand
 
-The class methods Loofah.scrub_fragment and Loofah.scrub_document are
-shorthand.
+The class methods `Loofah.scrub_html5_fragment` and `Loofah.scrub_html5_document` (and the corresponding HTML4 methods) are shorthand.
+
+These methods:
 
 ``` ruby
-Loofah.scrub_fragment(unsafe_html, :prune)
-Loofah.scrub_document(unsafe_html, :prune)
+Loofah.scrub_html5_fragment(unsafe_html, :prune)
+Loofah.scrub_html5_document(unsafe_html, :prune)
+Loofah.scrub_html4_fragment(unsafe_html, :prune)
+Loofah.scrub_html4_document(unsafe_html, :prune)
 Loofah.scrub_xml_fragment(bad_xml, custom_scrubber)
 Loofah.scrub_xml_document(bad_xml, custom_scrubber)
 ```
 
-are the same thing as (and arguably semantically clearer than):
+do the same thing as (and arguably semantically clearer than):
 
 ``` ruby
-Loofah.fragment(unsafe_html).scrub!(:prune)
-Loofah.document(unsafe_html).scrub!(:prune)
+Loofah.html5_fragment(unsafe_html).scrub!(:prune)
+Loofah.html5_document(unsafe_html).scrub!(:prune)
+Loofah.html4_fragment(unsafe_html).scrub!(:prune)
+Loofah.html4_document(unsafe_html).scrub!(:prune)
 Loofah.xml_fragment(bad_xml).scrub!(custom_scrubber)
 Loofah.xml_document(bad_xml).scrub!(custom_scrubber)
 ```
@@ -267,10 +275,9 @@ Loofah.xml_document(bad_xml).scrub!(custom_scrubber)
 
 ### View Helpers
 
-Loofah has two "view helpers": Loofah::Helpers.sanitize and
-Loofah::Helpers.strip_tags, both of which are drop-in replacements for
-the Rails ActionView helpers of the same name.
-These are no longer required automatically. You must require `loofah/helpers`. 
+Loofah has two "view helpers": `Loofah::Helpers.sanitize` and `Loofah::Helpers.strip_tags`, both of which are drop-in replacements for the Rails Action View helpers of the same name.
+
+These are not required automatically. You must require `loofah/helpers` to use them.
 
 
 ## Requirements
@@ -296,8 +303,6 @@ And the mailing list is on Google Groups:
 * Mail: loofah-talk@googlegroups.com
 * Archive: https://groups.google.com/forum/#!forum/loofah-talk
 
-And the IRC channel is \#loofah on freenode.
-
 Consider subscribing to [Tidelift][tidelift] which provides license assurances and timely security notifications for your open source dependencies, including Loofah. [Tidelift][tidelift] subscriptions also help the Loofah maintainers fund our [automated testing](https://ci.nokogiri.org) which in turn allows us to ship releases, bugfixes, and security updates more often.
 
   [tidelift]: https://tidelift.com/subscription/pkg/rubygems-loofah?utm_source=undefined&utm_medium=referral&utm_campaign=enterprise
@@ -308,26 +313,12 @@ Consider subscribing to [Tidelift][tidelift] which provides license assurances a
 See [`SECURITY.md`](SECURITY.md) for vulnerability reporting details.
 
 
-### "Secure by Default"
-
-Some tools may incorrectly report Loofah as a potential security
-vulnerability.
-
-Loofah depends on Nokogiri, and it's _possible_ to use Nokogiri in a
-dangerous way (by enabling its DTDLOAD option and disabling its NONET
-option). This specifically allows the opportunity for an XML External
-Entity (XXE) vulnerability if the XML data is untrusted.
-
-However, Loofah __never enables this Nokogiri configuration__; Loofah
-never enables DTDLOAD, and it never disables NONET, thereby protecting
-you by default from this XXE vulnerability.
-
-
 ## Related Links
 
+* loofah-activerecord: https://github.com/flavorjones/loofah-activerecord
 * Nokogiri: http://nokogiri.org
 * libxml2: http://xmlsoft.org
-* html5lib: https://code.google.com/p/html5lib
+* html5lib: https://github.com/html5lib/
 
 
 ## Authors
@@ -355,8 +346,7 @@ The following people have generously funded Loofah:
 
 ## Historical Note
 
-This library was formerly known as Dryopteris, which was a very bad
-name that nobody could spell properly.
+This library was once named "Dryopteris", which was a very bad name that nobody could spell properly.
 
 
 ## License

--- a/lib/loofah.rb
+++ b/lib/loofah.rb
@@ -19,8 +19,11 @@ require_relative "loofah/xml/document"
 require_relative "loofah/xml/document_fragment"
 require_relative "loofah/html4/document"
 require_relative "loofah/html4/document_fragment"
-require_relative "loofah/html5/document"
-require_relative "loofah/html5/document_fragment"
+
+if Nokogiri.respond_to?(:uses_gumbo?) && Nokogiri.uses_gumbo?
+  require_relative "loofah/html5/document"
+  require_relative "loofah/html5/document_fragment"
+end
 
 # == Strings and IO Objects as Input
 #
@@ -54,6 +57,10 @@ module Loofah
   HTML = HTML4
 
   class << self
+    def html5_support?
+      Nokogiri.respond_to?(:uses_gumbo?) && Nokogiri.uses_gumbo?
+    end
+
     # Shortcut for Loofah::HTML4::Document.parse(*args, &block)
     #
     # This method accepts the same parameters as Nokogiri::HTML4::Document.parse
@@ -78,28 +85,46 @@ module Loofah
       Loofah::HTML4::DocumentFragment.parse(string_or_io).scrub!(method)
     end
 
-    # Shortcut for Loofah::HTML5::Document.parse(*args, &block)
-    #
-    # This method accepts the same parameters as Nokogiri::HTML5::Document.parse
-    def html5_document(*args, &block)
-      Loofah::HTML5::Document.parse(*args, &block)
-    end
+    if Loofah.html5_support?
+      # Shortcut for Loofah::HTML5::Document.parse(*args, &block)
+      #
+      # This method accepts the same parameters as Nokogiri::HTML5::Document.parse
+      def html5_document(*args, &block)
+        Loofah::HTML5::Document.parse(*args, &block)
+      end
 
-    # Shortcut for Loofah::HTML5::DocumentFragment.parse(*args, &block)
-    #
-    # This method accepts the same parameters as Nokogiri::HTML5::DocumentFragment.parse
-    def html5_fragment(*args, &block)
-      Loofah::HTML5::DocumentFragment.parse(*args, &block)
-    end
+      # Shortcut for Loofah::HTML5::DocumentFragment.parse(*args, &block)
+      #
+      # This method accepts the same parameters as Nokogiri::HTML5::DocumentFragment.parse
+      def html5_fragment(*args, &block)
+        Loofah::HTML5::DocumentFragment.parse(*args, &block)
+      end
 
-    # Shortcut for Loofah::HTML5::Document.parse(string_or_io).scrub!(method)
-    def scrub_html5_document(string_or_io, method)
-      Loofah::HTML5::Document.parse(string_or_io).scrub!(method)
-    end
+      # Shortcut for Loofah::HTML5::Document.parse(string_or_io).scrub!(method)
+      def scrub_html5_document(string_or_io, method)
+        Loofah::HTML5::Document.parse(string_or_io).scrub!(method)
+      end
 
-    # Shortcut for Loofah::HTML5::DocumentFragment.parse(string_or_io).scrub!(method)
-    def scrub_html5_fragment(string_or_io, method)
-      Loofah::HTML5::DocumentFragment.parse(string_or_io).scrub!(method)
+      # Shortcut for Loofah::HTML5::DocumentFragment.parse(string_or_io).scrub!(method)
+      def scrub_html5_fragment(string_or_io, method)
+        Loofah::HTML5::DocumentFragment.parse(string_or_io).scrub!(method)
+      end
+    else
+      def html5_document(*args, &block)
+        raise NotImplementedError, "HTML5 is not supported by your version of Nokogiri"
+      end
+
+      def html5_fragment(*args, &block)
+        raise NotImplementedError, "HTML5 is not supported by your version of Nokogiri"
+      end
+
+      def scrub_html5_document(string_or_io, method)
+        raise NotImplementedError, "HTML5 is not supported by your version of Nokogiri"
+      end
+
+      def scrub_html5_fragment(string_or_io, method)
+        raise NotImplementedError, "HTML5 is not supported by your version of Nokogiri"
+      end
     end
 
     alias_method :document, :html4_document

--- a/lib/loofah.rb
+++ b/lib/loofah.rb
@@ -3,6 +3,23 @@ $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__))) unless $LOAD_PATH.i
 
 require "nokogiri"
 
+module Loofah
+  class << self
+    def html5_support?
+      # Note that Loofah can only support HTML5 in Nokogiri >= 1.14.0 because it requires the
+      # subclassing fix from https://github.com/sparklemotion/nokogiri/pull/2534
+      unless @html5_support_set
+        @html5_support = (
+          Gem::Version.new(Nokogiri::VERSION) > Gem::Version.new("1.14.0") &&
+          Nokogiri.uses_gumbo?
+        )
+        @html5_support_set = true
+      end
+      @html5_support
+    end
+  end
+end
+
 require_relative "loofah/version"
 require_relative "loofah/metahelpers"
 require_relative "loofah/elements"
@@ -57,10 +74,6 @@ module Loofah
   HTML = HTML4
 
   class << self
-    def html5_support?
-      Nokogiri.respond_to?(:uses_gumbo?) && Nokogiri.uses_gumbo?
-    end
-
     # Shortcut for Loofah::HTML4::Document.parse(*args, &block)
     #
     # This method accepts the same parameters as Nokogiri::HTML4::Document.parse

--- a/lib/loofah.rb
+++ b/lib/loofah.rb
@@ -17,8 +17,8 @@ require_relative "loofah/scrubbers"
 require_relative "loofah/instance_methods"
 require_relative "loofah/xml/document"
 require_relative "loofah/xml/document_fragment"
-require_relative "loofah/html/document"
-require_relative "loofah/html/document_fragment"
+require_relative "loofah/html4/document"
+require_relative "loofah/html4/document_fragment"
 
 # == Strings and IO Objects as Input
 #
@@ -29,17 +29,20 @@ require_relative "loofah/html/document_fragment"
 # quantities of docs.
 #
 module Loofah
+  # Alias for Loofah::HTML4
+  HTML = HTML4
+
   class << self
-    # Shortcut for Loofah::HTML::Document.parse
-    # This method accepts the same parameters as Nokogiri::HTML::Document.parse
+    # Shortcut for Loofah::HTML4::Document.parse
+    # This method accepts the same parameters as Nokogiri::HTML4::Document.parse
     def document(*args, &block)
-      remove_comments_before_html_element Loofah::HTML::Document.parse(*args, &block)
+      remove_comments_before_html_element(Loofah::HTML4::Document.parse(*args, &block))
     end
 
-    # Shortcut for Loofah::HTML::DocumentFragment.parse
-    # This method accepts the same parameters as Nokogiri::HTML::DocumentFragment.parse
+    # Shortcut for Loofah::HTML4::DocumentFragment.parse
+    # This method accepts the same parameters as Nokogiri::HTML4::DocumentFragment.parse
     def fragment(*args, &block)
-      Loofah::HTML::DocumentFragment.parse(*args, &block)
+      Loofah::HTML4::DocumentFragment.parse(*args, &block)
     end
 
     # Shortcut for Loofah.fragment(string_or_io).scrub!(method)

--- a/lib/loofah.rb
+++ b/lib/loofah.rb
@@ -14,7 +14,7 @@ require_relative "loofah/html5/scrub"
 require_relative "loofah/scrubber"
 require_relative "loofah/scrubbers"
 
-require_relative "loofah/instance_methods"
+require_relative "loofah/concerns"
 require_relative "loofah/xml/document"
 require_relative "loofah/xml/document_fragment"
 require_relative "loofah/html4/document"

--- a/lib/loofah.rb
+++ b/lib/loofah.rb
@@ -19,6 +19,8 @@ require_relative "loofah/xml/document"
 require_relative "loofah/xml/document_fragment"
 require_relative "loofah/html4/document"
 require_relative "loofah/html4/document_fragment"
+require_relative "loofah/html5/document"
+require_relative "loofah/html5/document_fragment"
 
 # == Strings and IO Objects as Input
 #
@@ -26,12 +28,19 @@ require_relative "loofah/html4/document_fragment"
 #
 # - Loofah.html4_document
 # - Loofah.html4_fragment
-# - Loofah.xml_document
-# - Loofah.xml_fragment
 # - Loofah.scrub_html4_document
 # - Loofah.scrub_html4_fragment
+#
+# - Loofah.html5_document
+# - Loofah.html5_fragment
+# - Loofah.scrub_html5_document
+# - Loofah.scrub_html5_fragment
+#
+# - Loofah.xml_document
+# - Loofah.xml_fragment
 # - Loofah.scrub_xml_document
 # - Loofah.scrub_xml_fragment
+#
 # - Loofah.document
 # - Loofah.fragment
 # - Loofah.scrub_document
@@ -67,6 +76,30 @@ module Loofah
     # Shortcut for Loofah::HTML4::DocumentFragment.parse(string_or_io).scrub!(method)
     def scrub_html4_fragment(string_or_io, method)
       Loofah::HTML4::DocumentFragment.parse(string_or_io).scrub!(method)
+    end
+
+    # Shortcut for Loofah::HTML5::Document.parse(*args, &block)
+    #
+    # This method accepts the same parameters as Nokogiri::HTML5::Document.parse
+    def html5_document(*args, &block)
+      Loofah::HTML5::Document.parse(*args, &block)
+    end
+
+    # Shortcut for Loofah::HTML5::DocumentFragment.parse(*args, &block)
+    #
+    # This method accepts the same parameters as Nokogiri::HTML5::DocumentFragment.parse
+    def html5_fragment(*args, &block)
+      Loofah::HTML5::DocumentFragment.parse(*args, &block)
+    end
+
+    # Shortcut for Loofah::HTML5::Document.parse(string_or_io).scrub!(method)
+    def scrub_html5_document(string_or_io, method)
+      Loofah::HTML5::Document.parse(string_or_io).scrub!(method)
+    end
+
+    # Shortcut for Loofah::HTML5::DocumentFragment.parse(string_or_io).scrub!(method)
+    def scrub_html5_fragment(string_or_io, method)
+      Loofah::HTML5::DocumentFragment.parse(string_or_io).scrub!(method)
     end
 
     alias_method :document, :html4_document

--- a/lib/loofah.rb
+++ b/lib/loofah.rb
@@ -22,46 +22,67 @@ require_relative "loofah/html4/document_fragment"
 
 # == Strings and IO Objects as Input
 #
-# Loofah.document and Loofah.fragment accept any IO object in addition
-# to accepting a string. That IO object could be a file, or a socket,
-# or a StringIO, or anything that responds to +read+ and
-# +close+. Which makes it particularly easy to sanitize mass
-# quantities of docs.
+# The following methods accept any IO object in addition to accepting a string:
+#
+# - Loofah.html4_document
+# - Loofah.html4_fragment
+# - Loofah.xml_document
+# - Loofah.xml_fragment
+# - Loofah.scrub_html4_document
+# - Loofah.scrub_html4_fragment
+# - Loofah.scrub_xml_document
+# - Loofah.scrub_xml_fragment
+# - Loofah.document
+# - Loofah.fragment
+# - Loofah.scrub_document
+# - Loofah.scrub_fragment
+#
+# That IO object could be a file, or a socket, or a StringIO, or anything that responds to +read+
+# and +close+.
 #
 module Loofah
   # Alias for Loofah::HTML4
   HTML = HTML4
 
   class << self
-    # Shortcut for Loofah::HTML4::Document.parse
+    # Shortcut for Loofah::HTML4::Document.parse(*args, &block)
+    #
     # This method accepts the same parameters as Nokogiri::HTML4::Document.parse
-    def document(*args, &block)
-      remove_comments_before_html_element(Loofah::HTML4::Document.parse(*args, &block))
+    def html4_document(*args, &block)
+      Loofah::HTML4::Document.parse(*args, &block)
     end
 
-    # Shortcut for Loofah::HTML4::DocumentFragment.parse
+    # Shortcut for Loofah::HTML4::DocumentFragment.parse(*args, &block)
+    #
     # This method accepts the same parameters as Nokogiri::HTML4::DocumentFragment.parse
-    def fragment(*args, &block)
+    def html4_fragment(*args, &block)
       Loofah::HTML4::DocumentFragment.parse(*args, &block)
     end
 
-    # Shortcut for Loofah.fragment(string_or_io).scrub!(method)
-    def scrub_fragment(string_or_io, method)
-      Loofah.fragment(string_or_io).scrub!(method)
+    # Shortcut for Loofah::HTML4::Document.parse(string_or_io).scrub!(method)
+    def scrub_html4_document(string_or_io, method)
+      Loofah::HTML4::Document.parse(string_or_io).scrub!(method)
     end
 
-    # Shortcut for Loofah.document(string_or_io).scrub!(method)
-    def scrub_document(string_or_io, method)
-      Loofah.document(string_or_io).scrub!(method)
+    # Shortcut for Loofah::HTML4::DocumentFragment.parse(string_or_io).scrub!(method)
+    def scrub_html4_fragment(string_or_io, method)
+      Loofah::HTML4::DocumentFragment.parse(string_or_io).scrub!(method)
     end
 
-    # Shortcut for Loofah::XML::Document.parse
+    alias_method :document, :html4_document
+    alias_method :fragment, :html4_fragment
+    alias_method :scrub_document, :scrub_html4_document
+    alias_method :scrub_fragment, :scrub_html4_fragment
+
+    # Shortcut for Loofah::XML::Document.parse(*args, &block)
+    #
     # This method accepts the same parameters as Nokogiri::XML::Document.parse
     def xml_document(*args, &block)
       Loofah::XML::Document.parse(*args, &block)
     end
 
-    # Shortcut for Loofah::XML::DocumentFragment.parse
+    # Shortcut for Loofah::XML::DocumentFragment.parse(*args, &block)
+    #
     # This method accepts the same parameters as Nokogiri::XML::DocumentFragment.parse
     def xml_fragment(*args, &block)
       Loofah::XML::DocumentFragment.parse(*args, &block)
@@ -80,24 +101,6 @@ module Loofah
     # A helper to remove extraneous whitespace from text-ified HTML
     def remove_extraneous_whitespace(string)
       string.gsub(/\n\s*\n\s*\n/, "\n\n")
-    end
-
-    private
-
-    # remove comments that exist outside of the HTML element.
-    #
-    # these comments are allowed by the HTML spec:
-    #
-    #    https://www.w3.org/TR/html401/struct/global.html#h-7.1
-    #
-    # but are not scrubbed by Loofah because these nodes don't meet
-    # the contract that scrubbers expect of a node (e.g., it can be
-    # replaced, sibling and children nodes can be created).
-    def remove_comments_before_html_element(doc)
-      doc.children.each do |child|
-        child.unlink if child.comment?
-      end
-      doc
     end
   end
 end

--- a/lib/loofah/concerns.rb
+++ b/lib/loofah/concerns.rb
@@ -172,7 +172,7 @@ module Loofah
       end
 
       def document_klass
-        @document_klass ||= if (self == Loofah::HTML5::DocumentFragment)
+        @document_klass ||= if (Loofah.html5_support? && self == Loofah::HTML5::DocumentFragment)
           Loofah::HTML5::Document
         elsif (self == Loofah::HTML4::DocumentFragment)
           Loofah::HTML4::Document

--- a/lib/loofah/concerns.rb
+++ b/lib/loofah/concerns.rb
@@ -11,16 +11,16 @@ module Loofah
   #    span2div = Loofah::Scrubber.new do |node|
   #      node.name = "div" if node.name == "span"
   #    end
-  #    Loofah.html4_fragment("<span>foo</span><p>bar</p>").scrub!(span2div).to_s
+  #    Loofah.html5_fragment("<span>foo</span><p>bar</p>").scrub!(span2div).to_s
   #    # => "<div>foo</div><p>bar</p>"
   #
   #  or
   #
   #    unsafe_html = "ohai! <div>div is safe</div> <script>but script is not</script>"
-  #    Loofah.html4_fragment(unsafe_html).scrub!(:strip).to_s
+  #    Loofah.html5_fragment(unsafe_html).scrub!(:strip).to_s
   #    # => "ohai! <div>div is safe</div> "
   #
-  #  Note that this method is called implicitly from the shortcuts Loofah.scrub_html4_fragment et
+  #  Note that this method is called implicitly from the shortcuts Loofah.scrub_html5_fragment et
   #  al.
   #
   #  Please see Scrubber for more information on implementation and traversal, and README.rdoc for
@@ -64,7 +64,7 @@ module Loofah
   end
 
   #
-  #  Overrides +text+ in HTML4::Document and HTML4::DocumentFragment, and mixes in +to_text+.
+  #  Overrides +text+ in Document and DocumentFragment classes, and mixes in +to_text+.
   #
   module TextBehavior
     #
@@ -74,14 +74,14 @@ module Loofah
     #  This method is significantly faster than #to_text, but isn't clever about whitespace around
     #  block elements.
     #
-    #    Loofah.html4_document("<h1>Title</h1><div>Content</div>").text
+    #    Loofah.html5_document("<h1>Title</h1><div>Content</div>").text
     #    # => "TitleContent"
     #
     #  By default, the returned text will have HTML entities escaped. If you want unescaped
     #  entities, and you understand that the result is unsafe to render in a browser, then you can
     #  pass an argument as shown:
     #
-    #    frag = Loofah.html4_fragment("&lt;script&gt;alert('EVIL');&lt;/script&gt;")
+    #    frag = Loofah.html5_fragment("&lt;script&gt;alert('EVIL');&lt;/script&gt;")
     #    # ok for browser:
     #    frag.text                                 # => "&lt;script&gt;alert('EVIL');&lt;/script&gt;"
     #    # decidedly not ok for browser:
@@ -110,7 +110,7 @@ module Loofah
     #  This method is slower than #text, but is clever about whitespace around block elements and
     #  line break elements.
     #
-    #    Loofah.html4_document("<h1>Title</h1><div>Content<br>Next line</div>").to_text
+    #    Loofah.html5_document("<h1>Title</h1><div>Content<br>Next line</div>").to_text
     #    # => "\nTitle\n\nContent\nNext line\n"
     #
     def to_text(options = {})

--- a/lib/loofah/helpers.rb
+++ b/lib/loofah/helpers.rb
@@ -8,7 +8,7 @@ module Loofah
       #   Loofah::Helpers.strip_tags("<div>Hello <b>there</b></div>") # => "Hello there"
       #
       def strip_tags(string_or_io)
-        Loofah.fragment(string_or_io).text
+        Loofah.html4_fragment(string_or_io).text
       end
 
       #
@@ -17,7 +17,7 @@ module Loofah
       #   Loofah::Helpers.sanitize("<script src=http://ha.ckers.org/xss.js></script>") # => "&lt;script src=\"http://ha.ckers.org/xss.js\"&gt;&lt;/script&gt;"
       #
       def sanitize(string_or_io)
-        loofah_fragment = Loofah.fragment(string_or_io)
+        loofah_fragment = Loofah.html4_fragment(string_or_io)
         loofah_fragment.scrub!(:strip)
         loofah_fragment.xpath("./form").each { |form| form.remove }
         loofah_fragment.to_s

--- a/lib/loofah/html4/document.rb
+++ b/lib/loofah/html4/document.rb
@@ -10,34 +10,7 @@ module Loofah
       include Loofah::ScrubBehavior::Node
       include Loofah::DocumentDecorator
       include Loofah::TextBehavior
-
-      class << self
-        def parse(*args, &block)
-          remove_comments_before_html_element(super)
-        end
-
-        private
-
-        # remove comments that exist outside of the HTML element.
-        #
-        # these comments are allowed by the HTML spec:
-        #
-        #    https://www.w3.org/TR/html401/struct/global.html#h-7.1
-        #
-        # but are not scrubbed by Loofah because these nodes don't meet
-        # the contract that scrubbers expect of a node (e.g., it can be
-        # replaced, sibling and children nodes can be created).
-        def remove_comments_before_html_element(doc)
-          doc.children.each do |child|
-            child.unlink if child.comment?
-          end
-          doc
-        end
-      end
-
-      def serialize_root
-        at_xpath("/html/body")
-      end
+      include Loofah::HtmlDocumentBehavior
     end
   end
 end

--- a/lib/loofah/html4/document.rb
+++ b/lib/loofah/html4/document.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 module Loofah
-  module HTML # :nodoc:
+  module HTML4 # :nodoc:
     #
-    #  Subclass of Nokogiri::HTML::Document.
+    #  Subclass of Nokogiri::HTML4::Document.
     #
     #  See Loofah::ScrubBehavior and Loofah::TextBehavior for additional methods.
     #
-    class Document < Nokogiri::HTML::Document
+    class Document < Nokogiri::HTML4::Document
       include Loofah::ScrubBehavior::Node
       include Loofah::DocumentDecorator
       include Loofah::TextBehavior

--- a/lib/loofah/html4/document.rb
+++ b/lib/loofah/html4/document.rb
@@ -11,6 +11,30 @@ module Loofah
       include Loofah::DocumentDecorator
       include Loofah::TextBehavior
 
+      class << self
+        def parse(*args, &block)
+          remove_comments_before_html_element(super)
+        end
+
+        private
+
+        # remove comments that exist outside of the HTML element.
+        #
+        # these comments are allowed by the HTML spec:
+        #
+        #    https://www.w3.org/TR/html401/struct/global.html#h-7.1
+        #
+        # but are not scrubbed by Loofah because these nodes don't meet
+        # the contract that scrubbers expect of a node (e.g., it can be
+        # replaced, sibling and children nodes can be created).
+        def remove_comments_before_html_element(doc)
+          doc.children.each do |child|
+            child.unlink if child.comment?
+          end
+          doc
+        end
+      end
+
       def serialize_root
         at_xpath("/html/body")
       end

--- a/lib/loofah/html4/document_fragment.rb
+++ b/lib/loofah/html4/document_fragment.rb
@@ -1,22 +1,22 @@
 # frozen_string_literal: true
 module Loofah
-  module HTML # :nodoc:
+  module HTML4 # :nodoc:
     #
-    #  Subclass of Nokogiri::HTML::DocumentFragment.
+    #  Subclass of Nokogiri::HTML4::DocumentFragment.
     #
     #  See Loofah::ScrubBehavior and Loofah::TextBehavior for additional methods.
     #
-    class DocumentFragment < Nokogiri::HTML::DocumentFragment
+    class DocumentFragment < Nokogiri::HTML4::DocumentFragment
       include Loofah::TextBehavior
 
       class << self
         #
-        #  Overridden Nokogiri::HTML::DocumentFragment
+        #  Overridden Nokogiri::HTML5::DocumentFragment
         #  constructor. Applications should use Loofah.fragment to
         #  parse a fragment.
         #
         def parse(tags, encoding = nil)
-          doc = Loofah::HTML::Document.new
+          doc = Loofah::HTML4::Document.new
 
           encoding ||= tags.respond_to?(:encoding) ? tags.encoding.name : "UTF-8"
           doc.encoding = encoding

--- a/lib/loofah/html4/document_fragment.rb
+++ b/lib/loofah/html4/document_fragment.rb
@@ -10,11 +10,6 @@ module Loofah
       include Loofah::TextBehavior
 
       class << self
-        #
-        #  Overridden Nokogiri::HTML5::DocumentFragment
-        #  constructor. Applications should use Loofah.fragment to
-        #  parse a fragment.
-        #
         def parse(tags, encoding = nil)
           doc = Loofah::HTML4::Document.new
 

--- a/lib/loofah/html4/document_fragment.rb
+++ b/lib/loofah/html4/document_fragment.rb
@@ -8,30 +8,7 @@ module Loofah
     #
     class DocumentFragment < Nokogiri::HTML4::DocumentFragment
       include Loofah::TextBehavior
-
-      class << self
-        def parse(tags, encoding = nil)
-          doc = Loofah::HTML4::Document.new
-
-          encoding ||= tags.respond_to?(:encoding) ? tags.encoding.name : "UTF-8"
-          doc.encoding = encoding
-
-          new(doc, tags)
-        end
-      end
-
-      #
-      #  Returns the HTML markup contained by the fragment
-      #
-      def to_s
-        serialize_root.children.to_s
-      end
-
-      alias :serialize :to_s
-
-      def serialize_root
-        at_xpath("./body") || self
-      end
+      include Loofah::HtmlFragmentBehavior
     end
   end
 end

--- a/lib/loofah/html5/document.rb
+++ b/lib/loofah/html5/document.rb
@@ -10,34 +10,7 @@ module Loofah
       include Loofah::ScrubBehavior::Node
       include Loofah::DocumentDecorator
       include Loofah::TextBehavior
-
-      class << self
-        def parse(*args, &block)
-          remove_comments_before_html_element(super)
-        end
-
-        private
-
-        # remove comments that exist outside of the HTML element.
-        #
-        # these comments are allowed by the HTML spec:
-        #
-        #    https://www.w3.org/TR/html401/struct/global.html#h-7.1
-        #
-        # but are not scrubbed by Loofah because these nodes don't meet
-        # the contract that scrubbers expect of a node (e.g., it can be
-        # replaced, sibling and children nodes can be created).
-        def remove_comments_before_html_element(doc)
-          doc.children.each do |child|
-            child.unlink if child.comment?
-          end
-          doc
-        end
-      end
-
-      def serialize_root
-        at_xpath("/html/body")
-      end
+      include Loofah::HtmlDocumentBehavior
     end
   end
 end

--- a/lib/loofah/html5/document.rb
+++ b/lib/loofah/html5/document.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+module Loofah
+  module HTML5 # :nodoc:
+    #
+    #  Subclass of Nokogiri::HTML5::Document.
+    #
+    #  See Loofah::ScrubBehavior and Loofah::TextBehavior for additional methods.
+    #
+    class Document < Nokogiri::HTML5::Document
+      include Loofah::ScrubBehavior::Node
+      include Loofah::DocumentDecorator
+      include Loofah::TextBehavior
+
+      class << self
+        def parse(*args, &block)
+          remove_comments_before_html_element(super)
+        end
+
+        private
+
+        # remove comments that exist outside of the HTML element.
+        #
+        # these comments are allowed by the HTML spec:
+        #
+        #    https://www.w3.org/TR/html401/struct/global.html#h-7.1
+        #
+        # but are not scrubbed by Loofah because these nodes don't meet
+        # the contract that scrubbers expect of a node (e.g., it can be
+        # replaced, sibling and children nodes can be created).
+        def remove_comments_before_html_element(doc)
+          doc.children.each do |child|
+            child.unlink if child.comment?
+          end
+          doc
+        end
+      end
+
+      def serialize_root
+        at_xpath("/html/body")
+      end
+    end
+  end
+end

--- a/lib/loofah/html5/document_fragment.rb
+++ b/lib/loofah/html5/document_fragment.rb
@@ -8,30 +8,7 @@ module Loofah
     #
     class DocumentFragment < Nokogiri::HTML5::DocumentFragment
       include Loofah::TextBehavior
-
-      class << self
-        def parse(tags, encoding = nil)
-          doc = Loofah::HTML5::Document.new
-
-          encoding ||= tags.respond_to?(:encoding) ? tags.encoding.name : "UTF-8"
-          doc.encoding = encoding
-
-          new(doc, tags)
-        end
-      end
-
-      #
-      #  Returns the HTML markup contained by the fragment
-      #
-      def to_s
-        serialize_root.children.to_s
-      end
-
-      alias :serialize :to_s
-
-      def serialize_root
-        at_xpath("./body") || self
-      end
+      include Loofah::HtmlFragmentBehavior
     end
   end
 end

--- a/lib/loofah/html5/document_fragment.rb
+++ b/lib/loofah/html5/document_fragment.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+module Loofah
+  module HTML5 # :nodoc:
+    #
+    #  Subclass of Nokogiri::HTML5::DocumentFragment.
+    #
+    #  See Loofah::ScrubBehavior and Loofah::TextBehavior for additional methods.
+    #
+    class DocumentFragment < Nokogiri::HTML5::DocumentFragment
+      include Loofah::TextBehavior
+
+      class << self
+        def parse(tags, encoding = nil)
+          doc = Loofah::HTML5::Document.new
+
+          encoding ||= tags.respond_to?(:encoding) ? tags.encoding.name : "UTF-8"
+          doc.encoding = encoding
+
+          new(doc, tags)
+        end
+      end
+
+      #
+      #  Returns the HTML markup contained by the fragment
+      #
+      def to_s
+        serialize_root.children.to_s
+      end
+
+      alias :serialize :to_s
+
+      def serialize_root
+        at_xpath("./body") || self
+      end
+    end
+  end
+end

--- a/lib/loofah/html5/scrub.rb
+++ b/lib/loofah/html5/scrub.rb
@@ -184,8 +184,8 @@ module Loofah
         end
 
         def cdata_needs_escaping?(node)
-          # Nokogiri's HTML4 parser on JRuby doesn't flag the child of a `style` or `script` tag as cdata, but it acts that way
-          node.cdata? || (Nokogiri.jruby? && node.text? && (node.parent.name == "style" || node.parent.name == "script"))
+          # Nokogiri's HTML4 parser on JRuby doesn't flag the child of a `style` tag as cdata, but it acts that way
+          node.cdata? || (Nokogiri.jruby? && node.text? && node.parent.name == "style")
         end
 
         def cdata_escape(node)

--- a/lib/loofah/instance_methods.rb
+++ b/lib/loofah/instance_methods.rb
@@ -67,7 +67,7 @@ module Loofah
   end
 
   #
-  #  Overrides +text+ in HTML::Document and HTML::DocumentFragment,
+  #  Overrides +text+ in HTML4::Document and HTML4::DocumentFragment,
   #  and mixes in +to_text+.
   #
   module TextBehavior

--- a/lib/loofah/instance_methods.rb
+++ b/lib/loofah/instance_methods.rb
@@ -3,39 +3,36 @@ module Loofah
   #
   #  Mixes +scrub!+ into Document, DocumentFragment, Node and NodeSet.
   #
-  #  Traverse the document or fragment, invoking the +scrubber+ on
-  #  each node.
+  #  Traverse the document or fragment, invoking the +scrubber+ on each node.
   #
-  #  +scrubber+ must either be one of the symbols representing the
-  #  built-in scrubbers (see Scrubbers), or a Scrubber instance.
+  #  +scrubber+ must either be one of the symbols representing the built-in scrubbers (see
+  #  Scrubbers), or a Scrubber instance.
   #
   #    span2div = Loofah::Scrubber.new do |node|
   #      node.name = "div" if node.name == "span"
   #    end
-  #    Loofah.fragment("<span>foo</span><p>bar</p>").scrub!(span2div).to_s
+  #    Loofah.html4_fragment("<span>foo</span><p>bar</p>").scrub!(span2div).to_s
   #    # => "<div>foo</div><p>bar</p>"
   #
   #  or
   #
   #    unsafe_html = "ohai! <div>div is safe</div> <script>but script is not</script>"
-  #    Loofah.fragment(unsafe_html).scrub!(:strip).to_s
+  #    Loofah.html4_fragment(unsafe_html).scrub!(:strip).to_s
   #    # => "ohai! <div>div is safe</div> "
   #
-  #  Note that this method is called implicitly from
-  #  Loofah.scrub_fragment and Loofah.scrub_document.
+  #  Note that this method is called implicitly from the shortcuts Loofah.scrub_html4_fragment et
+  #  al.
   #
-  #  Please see Scrubber for more information on implementation and traversal, and
-  #  README.rdoc for more example usage.
+  #  Please see Scrubber for more information on implementation and traversal, and README.rdoc for
+  #  more example usage.
   #
   module ScrubBehavior
     module Node # :nodoc:
       def scrub!(scrubber)
         #
-        #  yes. this should be three separate methods. but nokogiri
-        #  decorates (or not) based on whether the module name has
-        #  already been included. and since documents get decorated
-        #  just like their constituent nodes, we need to jam all the
-        #  logic into a single module.
+        #  yes. this should be three separate methods. but nokogiri decorates (or not) based on
+        #  whether the module name has already been included. and since documents get decorated just
+        #  like their constituent nodes, we need to jam all the logic into a single module.
         #
         scrubber = ScrubBehavior.resolve_scrubber(scrubber)
         case self
@@ -67,26 +64,24 @@ module Loofah
   end
 
   #
-  #  Overrides +text+ in HTML4::Document and HTML4::DocumentFragment,
-  #  and mixes in +to_text+.
+  #  Overrides +text+ in HTML4::Document and HTML4::DocumentFragment, and mixes in +to_text+.
   #
   module TextBehavior
     #
-    #  Returns a plain-text version of the markup contained by the document,
-    #  with HTML entities encoded.
+    #  Returns a plain-text version of the markup contained by the document, with HTML entities
+    #  encoded.
     #
-    #  This method is significantly faster than #to_text, but isn't
-    #  clever about whitespace around block elements.
+    #  This method is significantly faster than #to_text, but isn't clever about whitespace around
+    #  block elements.
     #
-    #    Loofah.document("<h1>Title</h1><div>Content</div>").text
+    #    Loofah.html4_document("<h1>Title</h1><div>Content</div>").text
     #    # => "TitleContent"
     #
-    #  By default, the returned text will have HTML entities
-    #  escaped. If you want unescaped entities, and you understand
-    #  that the result is unsafe to render in a browser, then you
-    #  can pass an argument as shown:
+    #  By default, the returned text will have HTML entities escaped. If you want unescaped
+    #  entities, and you understand that the result is unsafe to render in a browser, then you can
+    #  pass an argument as shown:
     #
-    #    frag = Loofah.fragment("&lt;script&gt;alert('EVIL');&lt;/script&gt;")
+    #    frag = Loofah.html4_fragment("&lt;script&gt;alert('EVIL');&lt;/script&gt;")
     #    # ok for browser:
     #    frag.text                                 # => "&lt;script&gt;alert('EVIL');&lt;/script&gt;"
     #    # decidedly not ok for browser:
@@ -109,13 +104,13 @@ module Loofah
     alias :to_str :text
 
     #
-    #  Returns a plain-text version of the markup contained by the
-    #  fragment, with HTML entities encoded.
+    #  Returns a plain-text version of the markup contained by the fragment, with HTML entities
+    #  encoded.
     #
-    #  This method is slower than #text, but is clever about
-    #  whitespace around block elements and line break elements.
+    #  This method is slower than #text, but is clever about whitespace around block elements and
+    #  line break elements.
     #
-    #    Loofah.document("<h1>Title</h1><div>Content<br>Next line</div>").to_text
+    #    Loofah.html4_document("<h1>Title</h1><div>Content<br>Next line</div>").to_text
     #    # => "\nTitle\n\nContent\nNext line\n"
     #
     def to_text(options = {})

--- a/lib/loofah/scrubber.rb
+++ b/lib/loofah/scrubber.rb
@@ -24,7 +24,7 @@ module Loofah
   #
   #  This can then be run on a document:
   #
-  #    Loofah.fragment("<span>foo</span><p>bar</p>").scrub!(span2div).to_s
+  #    Loofah.html4_fragment("<span>foo</span><p>bar</p>").scrub!(span2div).to_s
   #    # => "<div>foo</div><p>bar</p>"
   #
   #  Scrubbers can be run on a document in either a top-down traversal (the

--- a/lib/loofah/scrubber.rb
+++ b/lib/loofah/scrubber.rb
@@ -24,7 +24,7 @@ module Loofah
   #
   #  This can then be run on a document:
   #
-  #    Loofah.html4_fragment("<span>foo</span><p>bar</p>").scrub!(span2div).to_s
+  #    Loofah.html5_fragment("<span>foo</span><p>bar</p>").scrub!(span2div).to_s
   #    # => "<div>foo</div><p>bar</p>"
   #
   #  Scrubbers can be run on a document in either a top-down traversal (the

--- a/lib/loofah/scrubbers.rb
+++ b/lib/loofah/scrubbers.rb
@@ -11,7 +11,7 @@ module Loofah
   #  +:strip+ removes unknown/unsafe tags, but leaves behind the pristine contents:
   #
   #     unsafe_html = "ohai! <div>div is safe</div> <foo>but foo is <b>not</b></foo>"
-  #     Loofah.fragment(unsafe_html).scrub!(:strip)
+  #     Loofah.html4_fragment(unsafe_html).scrub!(:strip)
   #     => "ohai! <div>div is safe</div> but foo is <b>not</b>"
   #
   #
@@ -20,7 +20,7 @@ module Loofah
   #  +:prune+ removes unknown/unsafe tags and their contents (including their subtrees):
   #
   #     unsafe_html = "ohai! <div>div is safe</div> <foo>but foo is <b>not</b></foo>"
-  #     Loofah.fragment(unsafe_html).scrub!(:prune)
+  #     Loofah.html4_fragment(unsafe_html).scrub!(:prune)
   #     => "ohai! <div>div is safe</div> "
   #
   #
@@ -29,7 +29,7 @@ module Loofah
   #  +:escape+ performs HTML entity escaping on the unknown/unsafe tags:
   #
   #     unsafe_html = "ohai! <div>div is safe</div> <foo>but foo is <b>not</b></foo>"
-  #     Loofah.fragment(unsafe_html).scrub!(:escape)
+  #     Loofah.html4_fragment(unsafe_html).scrub!(:escape)
   #     => "ohai! <div>div is safe</div> &lt;foo&gt;but foo is &lt;b&gt;not&lt;/b&gt;&lt;/foo&gt;"
   #
   #
@@ -41,7 +41,7 @@ module Loofah
   #  layer of paint on top of the HTML input to make it look nice.
   #
   #     messy_markup = "ohai! <div id='foo' class='bar' style='margin: 10px'>div with attributes</div>"
-  #     Loofah.fragment(messy_markup).scrub!(:whitewash)
+  #     Loofah.html4_fragment(messy_markup).scrub!(:whitewash)
   #     => "ohai! <div>div with attributes</div>"
   #
   #  One use case for this scrubber is to clean up HTML that was
@@ -56,7 +56,7 @@ module Loofah
   #  +:nofollow+ adds a rel="nofollow" attribute to all links
   #
   #     link_farmers_markup = "ohai! <a href='http://www.myswarmysite.com/'>I like your blog post</a>"
-  #     Loofah.fragment(link_farmers_markup).scrub!(:nofollow)
+  #     Loofah.html4_fragment(link_farmers_markup).scrub!(:nofollow)
   #     => "ohai! <a href='http://www.myswarmysite.com/' rel="nofollow">I like your blog post</a>"
   #
   #
@@ -65,7 +65,7 @@ module Loofah
   #  +:noopener+ adds a rel="noopener" attribute to all links
   #
   #     link_farmers_markup = "ohai! <a href='http://www.myswarmysite.com/'>I like your blog post</a>"
-  #     Loofah.fragment(link_farmers_markup).scrub!(:noopener)
+  #     Loofah.html4_fragment(link_farmers_markup).scrub!(:noopener)
   #     => "ohai! <a href='http://www.myswarmysite.com/' rel="noopener">I like your blog post</a>"
   #
   #
@@ -74,7 +74,7 @@ module Loofah
   #  +:unprintable+ removes unprintable Unicode characters.
   #
   #     markup = "<p>Some text with an unprintable character at the end\u2028</p>"
-  #     Loofah.fragment(markup).scrub!(:unprintable)
+  #     Loofah.html4_fragment(markup).scrub!(:unprintable)
   #     => "<p>Some text with an unprintable character at the end</p>"
   #
   #  You may not be able to see the unprintable character in the above example, but there is a
@@ -90,7 +90,7 @@ module Loofah
     #  +:strip+ removes unknown/unsafe tags, but leaves behind the pristine contents:
     #
     #     unsafe_html = "ohai! <div>div is safe</div> <foo>but foo is <b>not</b></foo>"
-    #     Loofah.fragment(unsafe_html).scrub!(:strip)
+    #     Loofah.html4_fragment(unsafe_html).scrub!(:strip)
     #     => "ohai! <div>div is safe</div> but foo is <b>not</b>"
     #
     class Strip < Scrubber
@@ -112,7 +112,7 @@ module Loofah
     #  +:prune+ removes unknown/unsafe tags and their contents (including their subtrees):
     #
     #     unsafe_html = "ohai! <div>div is safe</div> <foo>but foo is <b>not</b></foo>"
-    #     Loofah.fragment(unsafe_html).scrub!(:prune)
+    #     Loofah.html4_fragment(unsafe_html).scrub!(:prune)
     #     => "ohai! <div>div is safe</div> "
     #
     class Prune < Scrubber
@@ -133,7 +133,7 @@ module Loofah
     #  +:escape+ performs HTML entity escaping on the unknown/unsafe tags:
     #
     #     unsafe_html = "ohai! <div>div is safe</div> <foo>but foo is <b>not</b></foo>"
-    #     Loofah.fragment(unsafe_html).scrub!(:escape)
+    #     Loofah.html4_fragment(unsafe_html).scrub!(:escape)
     #     => "ohai! <div>div is safe</div> &lt;foo&gt;but foo is &lt;b&gt;not&lt;/b&gt;&lt;/foo&gt;"
     #
     class Escape < Scrubber
@@ -158,7 +158,7 @@ module Loofah
     #  layer of paint on top of the HTML input to make it look nice.
     #
     #     messy_markup = "ohai! <div id='foo' class='bar' style='margin: 10px'>div with attributes</div>"
-    #     Loofah.fragment(messy_markup).scrub!(:whitewash)
+    #     Loofah.html4_fragment(messy_markup).scrub!(:whitewash)
     #     => "ohai! <div>div with attributes</div>"
     #
     #  One use case for this scrubber is to clean up HTML that was
@@ -193,7 +193,7 @@ module Loofah
     #  +:nofollow+ adds a rel="nofollow" attribute to all links
     #
     #     link_farmers_markup = "ohai! <a href='http://www.myswarmysite.com/'>I like your blog post</a>"
-    #     Loofah.fragment(link_farmers_markup).scrub!(:nofollow)
+    #     Loofah.html4_fragment(link_farmers_markup).scrub!(:nofollow)
     #     => "ohai! <a href='http://www.myswarmysite.com/' rel="nofollow">I like your blog post</a>"
     #
     class NoFollow < Scrubber
@@ -214,7 +214,7 @@ module Loofah
     #  +:noopener+ adds a rel="noopener" attribute to all links
     #
     #     link_farmers_markup = "ohai! <a href='http://www.myswarmysite.com/'>I like your blog post</a>"
-    #     Loofah.fragment(link_farmers_markup).scrub!(:noopener)
+    #     Loofah.html4_fragment(link_farmers_markup).scrub!(:noopener)
     #     => "ohai! <a href='http://www.myswarmysite.com/' rel="noopener">I like your blog post</a>"
     #
     class NoOpener < Scrubber
@@ -253,7 +253,7 @@ module Loofah
     #  +:unprintable+ removes unprintable Unicode characters.
     #
     #     markup = "<p>Some text with an unprintable character at the end\u2028</p>"
-    #     Loofah.fragment(markup).scrub!(:unprintable)
+    #     Loofah.html4_fragment(markup).scrub!(:unprintable)
     #     => "<p>Some text with an unprintable character at the end</p>"
     #
     #  You may not be able to see the unprintable character in the above example, but there is a

--- a/lib/loofah/scrubbers.rb
+++ b/lib/loofah/scrubbers.rb
@@ -11,7 +11,7 @@ module Loofah
   #  +:strip+ removes unknown/unsafe tags, but leaves behind the pristine contents:
   #
   #     unsafe_html = "ohai! <div>div is safe</div> <foo>but foo is <b>not</b></foo>"
-  #     Loofah.html4_fragment(unsafe_html).scrub!(:strip)
+  #     Loofah.html5_fragment(unsafe_html).scrub!(:strip)
   #     => "ohai! <div>div is safe</div> but foo is <b>not</b>"
   #
   #
@@ -20,7 +20,7 @@ module Loofah
   #  +:prune+ removes unknown/unsafe tags and their contents (including their subtrees):
   #
   #     unsafe_html = "ohai! <div>div is safe</div> <foo>but foo is <b>not</b></foo>"
-  #     Loofah.html4_fragment(unsafe_html).scrub!(:prune)
+  #     Loofah.html5_fragment(unsafe_html).scrub!(:prune)
   #     => "ohai! <div>div is safe</div> "
   #
   #
@@ -29,7 +29,7 @@ module Loofah
   #  +:escape+ performs HTML entity escaping on the unknown/unsafe tags:
   #
   #     unsafe_html = "ohai! <div>div is safe</div> <foo>but foo is <b>not</b></foo>"
-  #     Loofah.html4_fragment(unsafe_html).scrub!(:escape)
+  #     Loofah.html5_fragment(unsafe_html).scrub!(:escape)
   #     => "ohai! <div>div is safe</div> &lt;foo&gt;but foo is &lt;b&gt;not&lt;/b&gt;&lt;/foo&gt;"
   #
   #
@@ -41,7 +41,7 @@ module Loofah
   #  layer of paint on top of the HTML input to make it look nice.
   #
   #     messy_markup = "ohai! <div id='foo' class='bar' style='margin: 10px'>div with attributes</div>"
-  #     Loofah.html4_fragment(messy_markup).scrub!(:whitewash)
+  #     Loofah.html5_fragment(messy_markup).scrub!(:whitewash)
   #     => "ohai! <div>div with attributes</div>"
   #
   #  One use case for this scrubber is to clean up HTML that was
@@ -56,7 +56,7 @@ module Loofah
   #  +:nofollow+ adds a rel="nofollow" attribute to all links
   #
   #     link_farmers_markup = "ohai! <a href='http://www.myswarmysite.com/'>I like your blog post</a>"
-  #     Loofah.html4_fragment(link_farmers_markup).scrub!(:nofollow)
+  #     Loofah.html5_fragment(link_farmers_markup).scrub!(:nofollow)
   #     => "ohai! <a href='http://www.myswarmysite.com/' rel="nofollow">I like your blog post</a>"
   #
   #
@@ -65,7 +65,7 @@ module Loofah
   #  +:noopener+ adds a rel="noopener" attribute to all links
   #
   #     link_farmers_markup = "ohai! <a href='http://www.myswarmysite.com/'>I like your blog post</a>"
-  #     Loofah.html4_fragment(link_farmers_markup).scrub!(:noopener)
+  #     Loofah.html5_fragment(link_farmers_markup).scrub!(:noopener)
   #     => "ohai! <a href='http://www.myswarmysite.com/' rel="noopener">I like your blog post</a>"
   #
   #
@@ -74,7 +74,7 @@ module Loofah
   #  +:unprintable+ removes unprintable Unicode characters.
   #
   #     markup = "<p>Some text with an unprintable character at the end\u2028</p>"
-  #     Loofah.html4_fragment(markup).scrub!(:unprintable)
+  #     Loofah.html5_fragment(markup).scrub!(:unprintable)
   #     => "<p>Some text with an unprintable character at the end</p>"
   #
   #  You may not be able to see the unprintable character in the above example, but there is a
@@ -90,7 +90,7 @@ module Loofah
     #  +:strip+ removes unknown/unsafe tags, but leaves behind the pristine contents:
     #
     #     unsafe_html = "ohai! <div>div is safe</div> <foo>but foo is <b>not</b></foo>"
-    #     Loofah.html4_fragment(unsafe_html).scrub!(:strip)
+    #     Loofah.html5_fragment(unsafe_html).scrub!(:strip)
     #     => "ohai! <div>div is safe</div> but foo is <b>not</b>"
     #
     class Strip < Scrubber
@@ -112,7 +112,7 @@ module Loofah
     #  +:prune+ removes unknown/unsafe tags and their contents (including their subtrees):
     #
     #     unsafe_html = "ohai! <div>div is safe</div> <foo>but foo is <b>not</b></foo>"
-    #     Loofah.html4_fragment(unsafe_html).scrub!(:prune)
+    #     Loofah.html5_fragment(unsafe_html).scrub!(:prune)
     #     => "ohai! <div>div is safe</div> "
     #
     class Prune < Scrubber
@@ -133,7 +133,7 @@ module Loofah
     #  +:escape+ performs HTML entity escaping on the unknown/unsafe tags:
     #
     #     unsafe_html = "ohai! <div>div is safe</div> <foo>but foo is <b>not</b></foo>"
-    #     Loofah.html4_fragment(unsafe_html).scrub!(:escape)
+    #     Loofah.html5_fragment(unsafe_html).scrub!(:escape)
     #     => "ohai! <div>div is safe</div> &lt;foo&gt;but foo is &lt;b&gt;not&lt;/b&gt;&lt;/foo&gt;"
     #
     class Escape < Scrubber
@@ -158,7 +158,7 @@ module Loofah
     #  layer of paint on top of the HTML input to make it look nice.
     #
     #     messy_markup = "ohai! <div id='foo' class='bar' style='margin: 10px'>div with attributes</div>"
-    #     Loofah.html4_fragment(messy_markup).scrub!(:whitewash)
+    #     Loofah.html5_fragment(messy_markup).scrub!(:whitewash)
     #     => "ohai! <div>div with attributes</div>"
     #
     #  One use case for this scrubber is to clean up HTML that was
@@ -193,7 +193,7 @@ module Loofah
     #  +:nofollow+ adds a rel="nofollow" attribute to all links
     #
     #     link_farmers_markup = "ohai! <a href='http://www.myswarmysite.com/'>I like your blog post</a>"
-    #     Loofah.html4_fragment(link_farmers_markup).scrub!(:nofollow)
+    #     Loofah.html5_fragment(link_farmers_markup).scrub!(:nofollow)
     #     => "ohai! <a href='http://www.myswarmysite.com/' rel="nofollow">I like your blog post</a>"
     #
     class NoFollow < Scrubber
@@ -214,7 +214,7 @@ module Loofah
     #  +:noopener+ adds a rel="noopener" attribute to all links
     #
     #     link_farmers_markup = "ohai! <a href='http://www.myswarmysite.com/'>I like your blog post</a>"
-    #     Loofah.html4_fragment(link_farmers_markup).scrub!(:noopener)
+    #     Loofah.html5_fragment(link_farmers_markup).scrub!(:noopener)
     #     => "ohai! <a href='http://www.myswarmysite.com/' rel="noopener">I like your blog post</a>"
     #
     class NoOpener < Scrubber
@@ -253,7 +253,7 @@ module Loofah
     #  +:unprintable+ removes unprintable Unicode characters.
     #
     #     markup = "<p>Some text with an unprintable character at the end\u2028</p>"
-    #     Loofah.html4_fragment(markup).scrub!(:unprintable)
+    #     Loofah.html5_fragment(markup).scrub!(:unprintable)
     #     => "<p>Some text with an unprintable character at the end</p>"
     #
     #  You may not be able to see the unprintable character in the above example, but there is a

--- a/lib/loofah/xml/document_fragment.rb
+++ b/lib/loofah/xml/document_fragment.rb
@@ -8,11 +8,6 @@ module Loofah
     #
     class DocumentFragment < Nokogiri::XML::DocumentFragment
       class << self
-        #
-        #  Overridden Nokogiri::XML::DocumentFragment
-        #  constructor. Applications should use Loofah.fragment to
-        #  parse a fragment.
-        #
         def parse(tags)
           doc = Loofah::XML::Document.new
           doc.encoding = tags.encoding.name if tags.respond_to?(:encoding)

--- a/test/assets/testdata_sanitizer_tests1.dat
+++ b/test/assets/testdata_sanitizer_tests1.dat
@@ -2,546 +2,515 @@
   {
     "name": "IE_Comments",
     "input": "<!--[if gte IE 4]><script>alert('XSS');</script><![endif]-->",
-    "output": "&lt;!--[if gte IE 4]&gt;&lt;script&gt;alert('XSS');&lt;/script&gt;&lt;![endif]--&gt;"
+    "libxml": "&lt;!--[if gte IE 4]&gt;&lt;script&gt;alert('XSS');&lt;/script&gt;&lt;![endif]--&gt;"
   },
 
   {
     "name": "IE_Comments_2",
     "input": "<![if !IE 5]><script>alert('XSS');</script><![endif]>",
-    "output": "&lt;script&gt;alert('XSS');&lt;/script&gt;",
-    "xhtml": "&lt;![if !IE 5]&gt;&lt;script&gt;alert('XSS');&lt;/script&gt;&lt;![endif]&gt;",
-    "commentary": "output is libxml 2.9.13 and earlier, xhtml is libxml 2.9.14 and later, see libxml 148be64"
+    "libxml_lte_2.9.13": "&lt;script&gt;alert('XSS');&lt;/script&gt;",
+    "libxml_gte_2.9.14": "&lt;![if !IE 5]&gt;&lt;script&gt;alert('XSS');&lt;/script&gt;&lt;![endif]&gt;",
+    "libgumbo": "&lt;!--[if !IE 5]--&gt;&lt;script&gt;alert('XSS');&lt;/script&gt;&lt;!--[endif]--&gt;"
   },
 
   {
     "name": "allow_colons_in_path_component",
     "input": "<a href=\"./this:that\">foo</a>",
-    "output": "<a href='./this:that'>foo</a>"
+    "libxml": "<a href='./this:that'>foo</a>"
   },
 
   {
     "name": "background_attribute",
     "input": "<div background=\"javascript:alert('XSS')\"></div>",
-    "output": "<div/>",
-    "xhtml": "<div></div>",
-    "rexml": "<div></div>"
+    "libxml": "<div></div>"
   },
 
   {
     "name": "bgsound",
     "input": "<bgsound src=\"javascript:alert('XSS');\" />",
-    "output": "&lt;bgsound src=\"javascript:alert('XSS');\"/&gt;",
-    "rexml": "&lt;bgsound src=\"javascript:alert('XSS');\"&gt;&lt;/bgsound&gt;"
+    "libxml": "&lt;bgsound src='javascript:alert('XSS');'&gt;&lt;/bgsound&gt;",
+    "libgumbo": "&lt;bgsound src='javascript:alert('XSS');'&gt;"
   },
 
   {
     /* original */
     "name": "div_background_image_unicode_encoded",
     "input": "<div style=\"background-image:\u00a5\u00a2\u006C\u0028'\u006a\u0061\u00a6\u0061\u00a3\u0063\u00a2\u0069\u00a0\u00a4\u003a\u0061\u006c\u0065\u00a2\u00a4\u0028.1027\u0058.1053\u0053\u0027\u0029'\u0029\">foo</div>",
-    "output": "<div>foo</div>"
+    "libxml": "<div>foo</div>"
   },
 
   {
     /* from https://owasp.org/www-community/xss-filter-evasion-cheatsheet */
     "name": "div_background_image_unicode_encoded2",
     "input": "<DIV STYLE=\"background-image:\u0075\u0072\u006C\u0028'\u006a\u0061\u0076\u0061\u0073\u0063\u0072\u0069\u0070\u0074\u003a\u0061\u006c\u0065\u0072\u0074\u0028.1027\u0058.1053\u0053\u0027\u0029'\u0029\">foo</div>",
-    "output": "<div>foo</div>"
+    "libxml": "<div>foo</div>"
   },
 
   {
     /* uh, fix what appear to be typos that have propagated over the years */
     "name": "div_background_image_unicode_encoded3",
     "input": "<DIV STYLE=\"background-image:\u0075\u0072\u006C\u0028'\u006a\u0061\u0076\u0061\u0073\u0063\u0072\u0069\u0070\u0074\u003a\u0061\u006c\u0065\u0072\u0074\u0028\u0027\u0058\u0053\u0053\u0027\u0029'\u0029\">foo</div>",
-    "output": "<div>foo</div>"
+    "libxml": "<div>foo</div>"
   },
 
   {
     /* and finally a version that has a chance of actually demonstrating a javascript vulnerability */
     "name": "div_background_image_unicode_encoded4",
     "input": "<DIV STYLE=\"background-image:\u0075\u0072\u006C\u0028\u0027\u006a\u0061\u0076\u0061\u0073\u0063\u0072\u0069\u0070\u0074\u003a\u0061\u006c\u0065\u0072\u0074\u0028\u0031\u0032\u0033\u0034\u0029\u0027\u0029\">foo</div>",
-    "output": "<div>foo</div>"
+    "libxml": "<div>foo</div>"
   },
 
   {
     /* and put that version into a CSS hex-encoded string */
     "name": "div_background_image_unicode_encoded5",
     "input": "<DIV STYLE=\"background-image:\\0075\\0072\\006C\\0028\\0027\\006a\\0061\\0076\\0061\\0073\\0063\\0072\\0069\\0070\\0074\\003a\\0061\\006c\\0065\\0072\\0074\\0028\\0031\\0032\\0033\\0034\\0029\\0027\\0029\">foo</div>",
-    "output": "<div>foo</div>"
+    "libxml": "<div>foo</div>"
   },
 
   {
     /* and again without encoding the parens */
     "name": "div_background_image_unicode_encoded6",
     "input": "<DIV STYLE=\"background-image:\\0075\\0072\\006C(\\0027\\006a\\0061\\0076\\0061\\0073\\0063\\0072\\0069\\0070\\0074\\003a\\0061\\006c\\0065\\0072\\0074\\0028\\0031\\0032\\0033\\0034\\0029\\0027)\">foo</div>",
-    "output": "<div>foo</div>"
+    "libxml": "<div>foo</div>"
   },
 
   {
     "name": "div_expression",
     "input": "<div style=\"width: expression(alert('XSS'));\">foo</div>",
-    "output": "<div>foo</div>"
+    "libxml": "<div>foo</div>"
   },
 
   {
     "name": "double_open_angle_brackets",
     "input": "<img src=http://ha.ckers.org/scriptlet.html <",
-    "output": "<img src='http://ha.ckers.org/scriptlet.html'>",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "<img src='http://ha.ckers.org/scriptlet.html'>",
+    "libgumbo": "" /* it is indeed the empty result, see next test for a better test */
+  },
+
+  {
+    "name": "double_open_angle_brackets v2",
+    "input": "<div><img src=http://ha.ckers.org/scriptlet.html < </div>",
+    "libxml": "<div><img src='http://ha.ckers.org/scriptlet.html'></div>"
   },
 
   {
     "name": "double_open_angle_brackets_2",
     "input": "<script src=http://ha.ckers.org/scriptlet.html <",
-    "output": "&lt;script src=\"http://ha.ckers.org/scriptlet.html\"&gt;&lt;/script&gt;",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "&lt;script src=\"http://ha.ckers.org/scriptlet.html\"&gt;&lt;/script&gt;",
+    "libgumbo": "" /* it is indeed empty */
+  },
+
+  {
+    "name": "double_open_angle_brackets_2 v2",
+    "input": "<div><script src=http://ha.ckers.org/scriptlet.html < </div>",
+    "libxml": "<div>&lt;script src=\"http://ha.ckers.org/scriptlet.html\"&gt;&lt;/script&gt;</div>",
+    "libgumbo": "<div>&lt;script src='http://ha.ckers.org/scriptlet.html' &lt;='' div=''&gt;&lt;/script&gt;</div>"
   },
 
   {
     "name": "grave_accents",
     "input": "<img src=`javascript:alert('XSS')` />",
-    "output": "<img>",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "<img>"
   },
 
   {
     "name": "img_dynsrc_lowsrc",
     "input": "<img dynsrc=\"javascript:alert('XSS')\" />",
-    "output": "<img>",
-    "rexml": "<img />"
+    "libxml": "<img>"
   },
 
   {
     "name": "img_vbscript",
     "input": "<img src='vbscript:msgbox(\"XSS\")' />",
-    "output": "<img>",
-    "rexml": "<img />"
+    "libxml": "<img>"
   },
 
   {
     "name": "input_image",
     "input": "<input type=\"image\" src=\"javascript:alert('XSS');\" />",
-    "output": "<input type='image'>",
-    "rexml": "<input type='image' />"
+    "libxml": "<input type='image'>"
   },
 
   {
     "name": "link_stylesheets",
     "input": "<link rel=\"stylesheet\" href=\"javascript:alert('XSS');\" />",
-    "output": "&lt;link rel=\"stylesheet\" href=\"javascript:alert('XSS');\"&gt;",
-    "rexml": "&lt;link href=\"javascript:alert('XSS');\" rel=\"stylesheet\"/&gt;"
+    "libxml": "&lt;link rel=\"stylesheet\" href=\"javascript:alert('XSS');\"&gt;"
   },
 
   {
     "name": "link_stylesheets_2",
     "input": "<link rel=\"stylesheet\" href=\"http://ha.ckers.org/xss.css\" />",
-    "output": "&lt;link rel=\"stylesheet\" href=\"http://ha.ckers.org/xss.css\"&gt;",
-    "rexml": "&lt;link href=\"http://ha.ckers.org/xss.css\" rel=\"stylesheet\"/&gt;"
+    "libxml": "&lt;link rel=\"stylesheet\" href=\"http://ha.ckers.org/xss.css\"&gt;"
   },
 
   {
     "name": "list_style_image",
     "input": "<li style=\"list-style-image: url(javascript:alert('XSS'))\">foo</li>",
-    "output": "<li>foo</li>"
+    "libxml": "<li>foo</li>"
   },
 
   {
     "name": "no_closing_script_tags",
     "input": "<script src=http://ha.ckers.org/xss.js?<b>",
-    "output": "&lt;script src=\"http://ha.ckers.org/xss.js?&amp;lt;b\"&gt;&lt;/script&gt;",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "&lt;script src=\"http://ha.ckers.org/xss.js?&amp;lt;b\"&gt;&lt;/script&gt;",
+    "libgumbo": "&lt;script src='http://ha.ckers.org/xss.js?&lt;b'&gt;&lt;/script&gt;"
   },
 
   {
     "name": "non_alpha_non_digit",
     "input": "<script/XSS src=\"http://ha.ckers.org/xss.js\"></script>",
-    "output": "&lt;script src=\"http://ha.ckers.org/xss.js\"&gt;&lt;/script&gt;",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "&lt;script src=\"http://ha.ckers.org/xss.js\"&gt;&lt;/script&gt;",
+    "libgumbo": "&lt;script xss='' src='http://ha.ckers.org/xss.js'&gt;&lt;/script&gt;"
   },
 
   {
     "name": "non_alpha_non_digit_2",
     "input": "<a onclick!\\#$%&()*~+-_.,:;?@[/|\\]^`=alert(\"XSS\")>foo</a>",
-    "output": "<a>foo</a>",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "<a>foo</a>"
   },
 
   {
     "name": "non_alpha_non_digit_3",
     "input": "<img/src=\"http://ha.ckers.org/xss.js\"/>",
-    "output": "<img>",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "<img>",
+    "libgumbo": "<img src='http://ha.ckers.org/xss.js'>" /* see "should_allow_image_src_attribute" test */
   },
 
   {
     "name": "non_alpha_non_digit_II",
     "input": "<a href!\\#$%&()*~+-_.,:;?@[/|]^`=alert('XSS')>foo</a>",
-    "output": "<a>foo</a>",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "<a>foo</a>"
   },
 
   {
     "name": "non_alpha_non_digit_III",
     "input": "<a/href=\"javascript:alert('XSS');\">foo</a>",
-    "output": "<a>foo</a>",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "<a>foo</a>"
   },
 
   {
     "name": "platypus",
     "input": "<a href=\"http://www.ragingplatypus.com/\" style=\"display:block; position:absolute; left:0; top:0; width:100%; height:100%; z-index:1; background-color:black; background-image:url(http://www.ragingplatypus.com/i/cam-full.jpg); background-x:center; background-y:center; background-repeat:repeat;\">never trust your upstream platypus</a>",
-    "output": "<a href='http://www.ragingplatypus.com/' style='display:block;width:100%;height:100%;background-color:black;background-x:center;background-y:center;'>never trust your upstream platypus</a>"
+    "libxml": "<a href='http://www.ragingplatypus.com/' style='display:block;width:100%;height:100%;background-color:black;background-x:center;background-y:center;'>never trust your upstream platypus</a>"
   },
 
   {
     "name": "protocol_resolution_in_script_tag",
     "input": "<script src=//ha.ckers.org/.j></script>",
-    "output": "&lt;script src=\"//ha.ckers.org/.j\"&gt;&lt;/script&gt;",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "&lt;script src=\"//ha.ckers.org/.j\"&gt;&lt;/script&gt;"
   },
 
   {
     "name": "should_allow_anchors",
     "input": "<a href='foo' onclick='bar'><script>baz</script></a>",
-    "output": "<a href='foo'>&lt;script&gt;baz&lt;/script&gt;</a>"
+    "libxml": "<a href='foo'>&lt;script&gt;baz&lt;/script&gt;</a>"
   },
 
   {
     "name": "should_allow_image_alt_attribute",
     "input": "<img alt='foo' onclick='bar' />",
-    "output": "<img alt='foo'>",
-    "rexml": "<img alt='foo' />"
+    "libxml": "<img alt='foo'>"
   },
 
   {
     "name": "should_allow_image_height_attribute",
     "input": "<img height='foo' onclick='bar' />",
-    "output": "<img height='foo'>",
-    "rexml": "<img height='foo' />"
+    "libxml": "<img height='foo'>"
   },
 
   {
     "name": "should_allow_image_src_attribute",
     "input": "<img src='foo' onclick='bar' />",
-    "output": "<img src='foo'>",
-    "rexml": "<img src='foo' />"
+    "libxml": "<img src='foo'>"
   },
 
   {
     "name": "should_allow_image_width_attribute",
     "input": "<img width='foo' onclick='bar' />",
-    "output": "<img width='foo'>",
-    "rexml": "<img width='foo' />"
+    "libxml": "<img width='foo'>"
   },
 
   {
     "name": "should_handle_blank_text",
     "input": "",
-    "output": ""
+    "libxml": ""
   },
 
   {
     "name": "should_handle_malformed_image_tags",
     "input": "<img \"\"\"><script>alert(\"XSS\")</script>\">",
-    "output": "<img>&lt;script&gt;alert(\"XSS\")&lt;/script&gt;\"&gt;",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "<img>&lt;script&gt;alert(\"XSS\")&lt;/script&gt;\"&gt;"
   },
 
   {
     "name": "should_handle_non_html",
     "input": "abc",
-    "output": "abc"
+    "libxml": "abc"
   },
 
   {
     "name": "should_not_fall_for_ridiculous_hack",
     "input": "<img\nsrc\n=\n\"\nj\na\nv\na\ns\nc\nr\ni\np\nt\n:\na\nl\ne\nr\nt\n(\n'\nX\nS\nS\n'\n)\n\"\n />",
-    "output": "<img>",
-    "rexml": "<img />"
+    "libxml": "<img>"
   },
 
   {
     "name": "should_not_fall_for_xss_image_hack_0",
     "input": "<img src=\"javascript:alert('XSS');\" />",
-    "output": "<img>",
-    "rexml": "<img />"
+    "libxml": "<img>"
   },
 
   {
     "name": "should_not_fall_for_xss_image_hack_1",
     "input": "<img src=javascript:alert('XSS') />",
-    "output": "<img>",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "<img>"
   },
 
   {
     "name": "should_not_fall_for_xss_image_hack_10",
     "input": "<img src=\"jav&#x0A;ascript:alert('XSS');\" />",
-    "output": "<img>",
-    "rexml": "<img />"
+    "libxml": "<img>"
   },
 
   {
     "name": "should_not_fall_for_xss_image_hack_11",
     "input": "<img src=\"jav&#x0D;ascript:alert('XSS');\" />",
-    "output": "<img>",
-    "rexml": "<img />"
+    "libxml": "<img>"
   },
 
   {
     "name": "should_not_fall_for_xss_image_hack_12",
     "input": "<img src=\" &#14;  javascript:alert('XSS');\" />",
-    "output": "<img>",
-    "rexml": "<img />"
+    "libxml": "<img>"
   },
 
   {
     "name": "should_not_fall_for_xss_image_hack_13",
     "input": "<img src=\"&#x20;javascript:alert('XSS');\" />",
-    "output": "<img>",
-    "rexml": "<img />"
+    "libxml": "<img>"
   },
 
   {
     "name": "should_not_fall_for_xss_image_hack_14",
     "input": "<img src=\"&#xA0;javascript:alert('XSS');\" />",
-    "output": "<img>",
-    "rexml": "<img />"
+    "libxml": "<img>"
   },
 
   {
     "name": "should_not_fall_for_xss_image_hack_2",
     "input": "<img src=\"JaVaScRiPt:alert('XSS')\" />",
-    "output": "<img>",
-    "rexml": "<img />"
+    "libxml": "<img>"
   },
 
   {
     "name": "should_not_fall_for_xss_image_hack_3",
     "input": "<img src='javascript:alert(&quot;XSS&quot;)' />",
-    "output": "<img>",
-    "rexml": "<img />"
+    "libxml": "<img>"
   },
 
   {
     "name": "should_not_fall_for_xss_image_hack_4",
     "input": "<img src='javascript:alert(String.fromCharCode(88,83,83))' />",
-    "output": "<img>",
-    "rexml": "<img />"
+    "libxml": "<img>"
   },
 
   {
     "name": "should_not_fall_for_xss_image_hack_5",
     "input": "<img src='&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;&#97;&#108;&#101;&#114;&#116;&#40;&#39;&#88;&#83;&#83;&#39;&#41;' />",
-    "output": "<img>",
-    "rexml": "<img />"
+    "libxml": "<img>"
   },
 
   {
     "name": "should_not_fall_for_xss_image_hack_6",
     "input": "<img src='&#0000106;&#0000097;&#0000118;&#0000097;&#0000115;&#0000099;&#0000114;&#0000105;&#0000112;&#0000116;&#0000058;&#0000097;&#0000108;&#0000101;&#0000114;&#0000116;&#0000040;&#0000039;&#0000088;&#0000083;&#0000083;&#0000039;&#0000041' />",
-    "output": "<img>",
-    "rexml": "<img />"
+    "libxml": "<img>"
   },
 
   {
     "name": "should_not_fall_for_xss_image_hack_7",
     "input": "<img src='&#x6A;&#x61;&#x76;&#x61;&#x73;&#x63;&#x72;&#x69;&#x70;&#x74;&#x3A;&#x61;&#x6C;&#x65;&#x72;&#x74;&#x28;&#x27;&#x58;&#x53;&#x53;&#x27;&#x29' />",
-    "output": "<img>",
-    "rexml": "<img />"
+    "libxml": "<img>"
   },
 
   {
     "name": "should_not_fall_for_xss_image_hack_8",
     "input": "<img src=\"jav\tascript:alert('XSS');\" />",
-    "output": "<img>",
-    "rexml": "<img />"
+    "libxml": "<img>"
   },
 
   {
     "name": "should_not_fall_for_xss_image_hack_9",
     "input": "<img src=\"jav&#x09;ascript:alert('XSS');\" />",
-    "output": "<img>",
-    "rexml": "<img />"
+    "libxml": "<img>"
   },
 
   {
     "name": "should_sanitize_half_open_scripts",
     "input": "<img src=\"javascript:alert('XSS')\"",
-    "output": "<img>",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "<img>",
+    "libgumbo": "" /* indeed it is empty */
+  },
+
+  {
+    "name": "should_sanitize_half_open_scripts 2",
+    "input": "<div><img src=\"javascript:alert('XSS')\" </div>",
+    "libxml": "<div><img></div>"
   },
 
   {
     "name": "should_sanitize_invalid_script_tag",
     "input": "<script/XSS SRC=\"http://ha.ckers.org/xss.js\"></script>",
-    "output": "&lt;script src=\"http://ha.ckers.org/xss.js\"&gt;&lt;/script&gt;",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "&lt;script src=\"http://ha.ckers.org/xss.js\"&gt;&lt;/script&gt;",
+    "libgumbo": "&lt;script xss='' src='http://ha.ckers.org/xss.js'&gt;&lt;/script&gt;"
   },
 
   {
     "name": "should_sanitize_script_tag_with_multiple_open_brackets",
     "input": "<<script>alert(\"XSS\");//<</script>",
-    "output": "alert(\"XSS\");//",
-    "xhtml": "&lt;&lt;script&gt;alert('XSS');//&lt;&lt;/script&gt;",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "&lt;&lt;script&gt;alert('XSS');//&lt;&lt;/script&gt;"
   },
 
   {
-    "name": "should_sanitize_script_tag_with_multiple_open_brackets_2",
+    "name": "should_sanitize_script_tag_with_multiple_open_brackets_2a",
     "input": "<iframe src=http://ha.ckers.org/scriptlet.html\n<",
-    "output": "&lt;iframe src=\"http://ha.ckers.org/scriptlet.html\"&gt;&lt;/iframe&gt;",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "&lt;iframe src=\"http://ha.ckers.org/scriptlet.html\"&gt;&lt;/iframe&gt;",
+    "libgumbo": "" /* it is indeed empty, see next test */
+  },
+
+  {
+    "name": "should_sanitize_script_tag_with_multiple_open_brackets_2b",
+    "input": "<div><iframe src=http://ha.ckers.org/scriptlet.html\n< </div>",
+    "libxml": "<div>&lt;iframe src=\"http://ha.ckers.org/scriptlet.html\"&gt;&lt;/iframe&gt;</div>",
+    "libgumbo": "<div>&lt;iframe src='http://ha.ckers.org/scriptlet.html' &lt;='' div=''&gt;&lt;/iframe&gt;</div>"
   },
 
   {
     "name": "should_sanitize_tag_broken_up_by_null",
     "input": "<scr\u0000ipt>alert(\"XSS\")</scr\u0000ipt>",
-    "output": "&lt;scr&gt;&lt;/scr&gt;",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "&lt;scr&gt;&lt;/scr&gt;",
+    "libgumbo": "&lt;scr�ipt&gt;alert('XSS')&lt;/scr�ipt&gt;"
   },
 
   {
     "name": "should_sanitize_unclosed_script",
     "input": "<script src=http://ha.ckers.org/xss.js?<b>",
-    "output": "&lt;script src=\"http://ha.ckers.org/xss.js?&amp;lt;b\"&gt;&lt;/script&gt;",
-    "rexml": "Ill-formed XHTML!"
+    "libxml": "&lt;script src=\"http://ha.ckers.org/xss.js?&amp;lt;b\"&gt;&lt;/script&gt;",
+    "libgumbo": "&lt;script src='http://ha.ckers.org/xss.js?&lt;b'&gt;&lt;/script&gt;"
   },
 
   {
     "name": "should_strip_href_attribute_in_a_with_bad_protocols",
     "input": "<a href=\"javascript:XSS\" title=\"1\">boo</a>",
-    "output": "<a title='1'>boo</a>"
+    "libxml": "<a title='1'>boo</a>"
   },
 
   {
     "name": "should_strip_href_attribute_in_a_with_bad_protocols_and_whitespace",
     "input": "<a href=\" javascript:XSS\" title=\"1\">boo</a>",
-    "output": "<a title='1'>boo</a>"
+    "libxml": "<a title='1'>boo</a>"
   },
 
   {
     "name": "should_strip_src_attribute_in_img_with_bad_protocols",
     "input": "<img src=\"javascript:XSS\" title=\"1\">boo</img>",
-    "output": "<img title='1'>boo",
-    "rexml": "<img title='1' />"
+    "libxml": "<img title='1'>boo"
   },
 
   {
     "name": "should_strip_src_attribute_in_img_with_bad_protocols_and_whitespace",
     "input": "<img src=\" javascript:XSS\" title=\"1\">boo</img>",
-    "output": "<img title='1'>boo",
-    "rexml": "<img title='1' />"
+    "libxml": "<img title='1'>boo"
   },
 
   {
     "name": "xml_base",
     "input": "<div xml:base=\"javascript:alert('XSS');//\">foo</div>",
-    "output": "<div>foo</div>"
+    "libxml": "<div>foo</div>"
   },
 
   {
     "name": "xul",
     "input": "<p style=\"-moz-binding:url('http://ha.ckers.org/xssmoz.xml#xss')\">fubar</p>",
-    "output": "<p>fubar</p>"
+    "libxml": "<p>fubar</p>"
   },
 
   {
     "name": "quotes_in_attributes",
     "input": "<img src='foo' title='\"foo\" bar' />",
-    "rexml": "<img src='foo' title='\"foo\" bar' />",
-    "output": "<img src='foo' title='\"foo\" bar'>"
+    "libxml": "<img src='foo' title='\"foo\" bar'>",
+    "libgumbo": "<img src='foo' title='&quot;foo&quot; bar'>"
   },
 
   {
     "name": "uri_refs_in_svg_attributes",
     "input": "<rect fill='url(#foo)' />",
-    "rexml": "<rect fill='url(#foo)'></rect>",
-    "xhtml": "<rect fill='url(#foo)'></rect>",
-    "output": "<rect fill='url(#foo)'/>"
+    "libxml": "<rect fill='url(#foo)'></rect>"
   },
 
   {
     "name": "absolute_uri_refs_in_svg_attributes",
     "input": "<rect fill='url(http://bad.com/) #fff' />",
-    "rexml": "<rect fill='#fff'></rect>",
-    "xhtml": "<rect fill='#fff'></rect>",
-    "output": "<rect fill='#fff'/>"
+    "libxml": "<rect fill='#fff'></rect>"
   },
 
   {
     "name": "uri_ref_with_space_in svg_attribute",
     "input": "<rect fill='url(\n#foo)' />",
-    "rexml": "<rect fill='url(\n#foo)'></rect>",
-    "xhtml": "<rect fill='url(\n#foo)'></rect>",
-    "output": "<rect fill='url(\n#foo)'/>"
+    "libxml": "<rect fill='url(\n#foo)'></rect>"
   },
 
   {
     "name": "absolute_uri_ref_with_space_in svg_attribute",
     "input": "<rect fill=\"url(\nhttp://bad.com/)\" />",
-    "rexml": "<rect></rect>",
-    "xhtml": "<rect></rect>",
-    "output": "<rect/>"
+    "libxml": "<rect></rect>"
   },
 
   {
     "name": "allow_html5_image_tag",
     "input": "<image src='foo' />",
-    "rexml": "&lt;image src=\"foo\"&gt;&lt;/image&gt;",
-    "output": "&lt;image src=\"foo\"/&gt;"
+    "libxml": "&lt;image src=\"foo\"&gt;&lt;/image&gt;",
+    "libgumbo": "<img src='foo'>"
   },
 
   {
     "name": "style_attr_end_with_nothing",
     "input": "<div style=\"color: blue\" />",
-    "output": "<div style='color: blue;'/>",
-    "xhtml": "<div style='color:blue;'></div>",
-    "rexml": "<div style='color: blue;'></div>"
+    "libxml": "<div style='color:blue;'></div>"
   },
 
   {
     "name": "style_attr_end_with_space",
     "input": "<div style=\"color: blue \" />",
-    "output": "<div style='color: blue ;'/>",
-    "xhtml": "<div style='color:blue;'></div>",
-    "rexml": "<div style='color: blue ;'></div>"
+    "libxml": "<div style='color:blue;'></div>"
   },
 
   {
     "name": "style_attr_end_with_semicolon",
     "input": "<div style=\"color: blue;\" />",
-    "output": "<div style='color: blue;'/>",
-    "xhtml": "<div style='color:blue;'></div>",
-    "rexml": "<div style='color: blue;'></div>"
+    "libxml": "<div style='color:blue;'></div>"
   },
 
   {
     "name": "style_attr_end_with_semicolon_space",
     "input": "<div style=\"color: blue; \" />",
-    "output": "<div style='color: blue;'/>",
-    "xhtml": "<div style='color:blue;'></div>",
-    "rexml": "<div style='color: blue;'></div>"
+    "libxml": "<div style='color:blue;'></div>"
   },
 
   {
     "name": "style_attr_shorthand_important",
     "input": "<div style=\"border: 2px dashed gray !important;\" />",
-    "output": "<div style='border:2px dashed gray !important;'/>",
-    "xhtml": "<div style='border:2px dashed gray !important;'></div>",
-    "rexml": "<div style='border:2px dashed gray !important;'></div>"
+    "libxml": "<div style='border:2px dashed gray !important;'></div>"
   },
 
   {
-   "name": "attributes_with_embedded_quotes",
-   "input": "<img src=doesntexist.jpg\"'onerror=\"alert(1) />",
-   "output": "<img src='doesntexist.jpg%22'onerror=%22alert(1)'>",
-   "rexml": "Ill-formed XHTML!"
+    "name": "attributes_with_embedded_quotes",
+    "input": "<img src=doesntexist.jpg\"'onerror=\"alert(1) />",
+    "libxml": "<img src='doesntexist.jpg%22'onerror=%22alert(1)'>"
   },
 
   {
-   "name": "attributes_with_embedded_quotes_II",
-   "input": "<img src=notthere.jpg\"\"onerror=\"alert(2) />",
-   "output": "<img src='notthere.jpg%22%22onerror=%22alert(2)'>",
-   "rexml": "Ill-formed XHTML!"
+    "name": "attributes_with_embedded_quotes_II",
+    "input": "<img src=notthere.jpg\"\"onerror=\"alert(2) />",
+    "libxml": "<img src='notthere.jpg%22%22onerror=%22alert(2)'>"
   }
 ]

--- a/test/assets/testdata_sanitizer_tests1.dat
+++ b/test/assets/testdata_sanitizer_tests1.dat
@@ -84,27 +84,31 @@
     "name": "double_open_angle_brackets",
     "input": "<img src=http://ha.ckers.org/scriptlet.html <",
     "libxml": "<img src='http://ha.ckers.org/scriptlet.html'>",
-    "libgumbo": "" /* it is indeed the empty result, see next test for a better test */
+    "libgumbo": "", /* it is indeed the empty result, see next test for a better test */
+    "jruby": "<img src='http://ha.ckers.org/scriptlet.html'>&lt;"
   },
 
   {
     "name": "double_open_angle_brackets v2",
     "input": "<div><img src=http://ha.ckers.org/scriptlet.html < </div>",
-    "libxml": "<div><img src='http://ha.ckers.org/scriptlet.html'></div>"
+    "libxml": "<div><img src='http://ha.ckers.org/scriptlet.html'></div>",
+    "jruby": "<div><img src='http://ha.ckers.org/scriptlet.html'>&lt; </div>"
   },
 
   {
     "name": "double_open_angle_brackets_2",
     "input": "<script src=http://ha.ckers.org/scriptlet.html <",
     "libxml": "&lt;script src=\"http://ha.ckers.org/scriptlet.html\"&gt;&lt;/script&gt;",
-    "libgumbo": "" /* it is indeed empty */
+    "libgumbo": "", /* it is indeed empty */
+    "jruby": "&lt;script src='http://ha.ckers.org/scriptlet.html'&gt;&lt;&lt;/script&gt;"
   },
 
   {
     "name": "double_open_angle_brackets_2 v2",
     "input": "<div><script src=http://ha.ckers.org/scriptlet.html < </div>",
     "libxml": "<div>&lt;script src=\"http://ha.ckers.org/scriptlet.html\"&gt;&lt;/script&gt;</div>",
-    "libgumbo": "<div>&lt;script src='http://ha.ckers.org/scriptlet.html' &lt;='' div=''&gt;&lt;/script&gt;</div>"
+    "libgumbo": "<div>&lt;script src='http://ha.ckers.org/scriptlet.html' &lt;='' div=''&gt;&lt;/script&gt;</div>",
+    "jruby": "<div>&lt;script src='http://ha.ckers.org/scriptlet.html'&gt;&lt; &lt;/div&gt;&lt;/script&gt;</div>"
   },
 
   {
@@ -134,13 +138,15 @@
   {
     "name": "link_stylesheets",
     "input": "<link rel=\"stylesheet\" href=\"javascript:alert('XSS');\" />",
-    "libxml": "&lt;link rel=\"stylesheet\" href=\"javascript:alert('XSS');\"&gt;"
+    "libxml": "&lt;link rel=\"stylesheet\" href=\"javascript:alert('XSS');\"&gt;",
+    "jruby": "&lt;link href='javascript:alert('XSS');' rel='stylesheet'&gt;"
   },
 
   {
     "name": "link_stylesheets_2",
     "input": "<link rel=\"stylesheet\" href=\"http://ha.ckers.org/xss.css\" />",
-    "libxml": "&lt;link rel=\"stylesheet\" href=\"http://ha.ckers.org/xss.css\"&gt;"
+    "libxml": "&lt;link rel=\"stylesheet\" href=\"http://ha.ckers.org/xss.css\"&gt;",
+    "jruby": "&lt;link href='http://ha.ckers.org/xss.css' rel='stylesheet'&gt;"
   },
 
   {
@@ -160,7 +166,8 @@
     "name": "non_alpha_non_digit",
     "input": "<script/XSS src=\"http://ha.ckers.org/xss.js\"></script>",
     "libxml": "&lt;script src=\"http://ha.ckers.org/xss.js\"&gt;&lt;/script&gt;",
-    "libgumbo": "&lt;script xss='' src='http://ha.ckers.org/xss.js'&gt;&lt;/script&gt;"
+    "libgumbo": "&lt;script xss='' src='http://ha.ckers.org/xss.js'&gt;&lt;/script&gt;",
+    "jruby": "&lt;script&gt;&lt;/script&gt;"
   },
 
   {
@@ -361,7 +368,8 @@
     "name": "should_sanitize_invalid_script_tag",
     "input": "<script/XSS SRC=\"http://ha.ckers.org/xss.js\"></script>",
     "libxml": "&lt;script src=\"http://ha.ckers.org/xss.js\"&gt;&lt;/script&gt;",
-    "libgumbo": "&lt;script xss='' src='http://ha.ckers.org/xss.js'&gt;&lt;/script&gt;"
+    "libgumbo": "&lt;script xss='' src='http://ha.ckers.org/xss.js'&gt;&lt;/script&gt;",
+    "jruby": "&lt;script&gt;&lt;/script&gt;"
   },
 
   {
@@ -374,21 +382,24 @@
     "name": "should_sanitize_script_tag_with_multiple_open_brackets_2a",
     "input": "<iframe src=http://ha.ckers.org/scriptlet.html\n<",
     "libxml": "&lt;iframe src=\"http://ha.ckers.org/scriptlet.html\"&gt;&lt;/iframe&gt;",
-    "libgumbo": "" /* it is indeed empty, see next test */
+    "libgumbo": "", /* it is indeed empty, see next test */
+    "jruby": "&lt;iframe src='http://ha.ckers.org/scriptlet.html'&gt;&amp;lt;&lt;/iframe&gt;"
   },
 
   {
     "name": "should_sanitize_script_tag_with_multiple_open_brackets_2b",
     "input": "<div><iframe src=http://ha.ckers.org/scriptlet.html\n< </div>",
     "libxml": "<div>&lt;iframe src=\"http://ha.ckers.org/scriptlet.html\"&gt;&lt;/iframe&gt;</div>",
-    "libgumbo": "<div>&lt;iframe src='http://ha.ckers.org/scriptlet.html' &lt;='' div=''&gt;&lt;/iframe&gt;</div>"
+    "libgumbo": "<div>&lt;iframe src='http://ha.ckers.org/scriptlet.html' &lt;='' div=''&gt;&lt;/iframe&gt;</div>",
+    "jruby": "<div>&lt;iframe src='http://ha.ckers.org/scriptlet.html'&gt;&amp;lt; &amp;lt;/div&amp;gt;&lt;/iframe&gt;</div>"
   },
 
   {
     "name": "should_sanitize_tag_broken_up_by_null",
     "input": "<scr\u0000ipt>alert(\"XSS\")</scr\u0000ipt>",
     "libxml": "&lt;scr&gt;&lt;/scr&gt;",
-    "libgumbo": "&lt;scr�ipt&gt;alert('XSS')&lt;/scr�ipt&gt;"
+    "libgumbo": "&lt;scr�ipt&gt;alert('XSS')&lt;/scr�ipt&gt;",
+    "jruby": "&lt;scr \u0000ipt=''&gt;alert('XSS')&lt;/scr&gt;"
   },
 
   {
@@ -438,7 +449,8 @@
     "name": "quotes_in_attributes",
     "input": "<img src='foo' title='\"foo\" bar' />",
     "libxml": "<img src='foo' title='\"foo\" bar'>",
-    "libgumbo": "<img src='foo' title='&quot;foo&quot; bar'>"
+    "libgumbo": "<img src='foo' title='&quot;foo&quot; bar'>",
+    "jruby": "<img src='foo' title='%22foo%22 bar'>"
   },
 
   {
@@ -456,7 +468,8 @@
   {
     "name": "uri_ref_with_space_in svg_attribute",
     "input": "<rect fill='url(\n#foo)' />",
-    "libxml": "<rect fill='url(\n#foo)'></rect>"
+    "libxml": "<rect fill='url(\n#foo)'></rect>",
+    "jruby": "<rect fill='url(&#10;#foo)'></rect>"
   },
 
   {
@@ -469,7 +482,8 @@
     "name": "allow_html5_image_tag",
     "input": "<image src='foo' />",
     "libxml": "&lt;image src=\"foo\"&gt;&lt;/image&gt;",
-    "libgumbo": "<img src='foo'>"
+    "libgumbo": "<img src='foo'>",
+    "jruby": "&lt;image src='foo'&gt;"
   },
 
   {

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,4 +11,22 @@ class Loofah::TestCase < MiniTest::Spec
   class << self
     alias_method :context, :describe
   end
+
+  LOOFAH_HTML_DOCUMENT_CLASSES = if Loofah.html5_support?
+    [Loofah::HTML4::Document, Loofah::HTML5::Document]
+  else
+    [Loofah::HTML4::Document]
+  end
+
+  LOOFAH_HTML_DOCUMENT_FRAGMENT_CLASSES = if Loofah.html5_support?
+    [Loofah::HTML4::DocumentFragment, Loofah::HTML5::DocumentFragment]
+  else
+    [Loofah::HTML4::DocumentFragment]
+  end
+
+  LOOFAH_HTML_VERSIONS = if Loofah.html5_support?
+    [:html4, :html5]
+  else
+    [:html4]
+  end
 end

--- a/test/html5/test_sanitizer.rb
+++ b/test/html5/test_sanitizer.rb
@@ -10,11 +10,11 @@ class Html5TestSanitizer < Loofah::TestCase
   include Loofah
 
   def sanitize_xhtml(stream)
-    Loofah.fragment(stream).scrub!(:escape).to_xhtml
+    Loofah.html4_fragment(stream).scrub!(:escape).to_xhtml
   end
 
   def sanitize_html(stream)
-    Loofah.fragment(stream).scrub!(:escape).to_html
+    Loofah.html4_fragment(stream).scrub!(:escape).to_html
   end
 
   def check_sanitization(input, *possible_answers)
@@ -229,7 +229,7 @@ class Html5TestSanitizer < Loofah::TestCase
   end
 
   def test_figure_element_is_valid
-    fragment = Loofah.scrub_fragment("<span>hello</span> <figure>asd</figure>", :prune)
+    fragment = Loofah.scrub_html4_fragment("<span>hello</span> <figure>asd</figure>", :prune)
     assert fragment.at_css("figure"), "<figure> tag was scrubbed"
   end
 
@@ -288,226 +288,226 @@ class Html5TestSanitizer < Loofah::TestCase
 
   def test_css_list_style
     html = '<ul style="list-style: none"></ul>'
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/list-style/, sane.inner_html
   end
 
   def test_css_negative_value_sanitization
     html = "<span style=\"letter-spacing:-0.03em;\">"
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/-0.03em/, sane.inner_html
   end
 
   def test_css_negative_value_sanitization_shorthand_css_properties
     html = "<span style=\"margin-left:-0.05em;\">"
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/-0.05em/, sane.inner_html
   end
 
   def test_css_high_precision_value_shorthand_css_properties
     html = "<span style=\"margin-left:0.3333333334em;\">"
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/0.3333333334em/, sane.inner_html
   end
 
   def test_css_rem_value
     html = "<span style=\"margin-top:10rem;\">"
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/10rem/, sane.inner_html
   end
 
   def test_css_ch_value
     html = "<div style=\"width:60ch;\">"
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/60ch/, sane.inner_html
   end
 
   def test_css_vw_value
     html = "<div style=\"font-size: calc(16px + 1vw);\"></body>"
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/1vw/, sane.inner_html
   end
 
   def test_css_vh_value
     html = "<div style=\"height: 100vh;\"></body>"
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/100vh/, sane.inner_html
   end
 
   def test_css_Q_value
     html = "<div style=\"height: 10Q;\"></body>"
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/10Q/, sane.inner_html
   end
 
   def test_css_lh_value
     html = "<p style=\"line-height: 2lh;\"></body>"
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/2lh/, sane.inner_html
   end
 
   def test_css_vmin_value
     html = "<div style=\"width: 42vmin;\"></body>"
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/42vmin/, sane.inner_html
   end
 
   def test_css_vmax_value
     html = "<div style=\"width: 42vmax;\"></body>"
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/42vmax/, sane.inner_html
   end
 
   def test_css_function_sanitization_leaves_safelisted_functions_calc
     html = "<span style=\"width:calc(5%)\">"
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :strip).to_html)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :strip).to_html)
     assert_match %r/calc\(5%\)/, sane.inner_html
 
     html = "<span style=\"width: calc(5%)\">"
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :strip).to_html)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :strip).to_html)
     assert_match %r/calc\(5%\)/, sane.inner_html
   end
 
   def test_css_function_sanitization_leaves_safelisted_functions_rgb
     html = '<span style="color: rgb(255, 0, 0)">'
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :strip).to_html)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :strip).to_html)
     assert_match %r/rgb\(255, 0, 0\)/, sane.inner_html
   end
 
   def test_css_function_sanitization_leaves_safelisted_list_style_type
     html = "<ol style='list-style-type:lower-greek;'></ol>"
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :strip).to_html)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :strip).to_html)
     assert_match %r/list-style-type:lower-greek/, sane.inner_html
   end
 
   def test_css_function_sanitization_strips_style_attributes_with_unsafe_functions
     html = "<span style=\"width:url(data-evil-url)\">"
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :strip).to_html)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :strip).to_html)
     assert_match %r/<span><\/span>/, sane.inner_html
 
     html = "<span style=\"width: url(data-evil-url)\">"
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :strip).to_html)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :strip).to_html)
     assert_match %r/<span><\/span>/, sane.inner_html
   end
 
   def test_css_max_width
     html = '<div style="max-width: 100%;"></div>'
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/max-width/, sane.inner_html
   end
 
   def test_css_page_break_after
     html = '<div style="page-break-after:always;"></div>'
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/page-break-after:always/, sane.inner_html
   end
 
   def test_css_page_break_before
     html = '<div style="page-break-before:always;"></div>'
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/page-break-before:always/, sane.inner_html
   end
 
   def test_css_page_break_inside
     html = '<div style="page-break-inside:auto;"></div>'
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/page-break-inside:auto/, sane.inner_html
   end
 
   def test_css_align_content
     html = '<div style="align-content:flex-start;"></div>'
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/align-content:flex-start/, sane.inner_html
   end
 
   def test_css_align_items
     html = '<div style="align-items:stretch;"></div>'
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/align-items:stretch/, sane.inner_html
   end
 
   def test_css_align_self
     html = '<div style="align-self:auto;"></div>'
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/align-self:auto/, sane.inner_html
   end
 
   def test_css_flex
     html = '<div style="flex:none;"></div>'
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/flex:none/, sane.inner_html
   end
 
   def test_css_flex_basis
     html = '<div style="flex-basis:auto;"></div>'
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/flex-basis:auto/, sane.inner_html
   end
 
   def test_css_flex_direction
     html = '<div style="flex-direction:row;"></div>'
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/flex-direction:row/, sane.inner_html
   end
 
   def test_css_flex_flow
     html = '<div style="flex-flow:column wrap;"></div>'
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/flex-flow:column wrap/, sane.inner_html
   end
 
   def test_css_flex_grow
     html = '<div style="flex-grow:4;"></div>'
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/flex-grow:4/, sane.inner_html
   end
 
   def test_css_flex_shrink
     html = '<div style="flex-shrink:3;"></div>'
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/flex-shrink:3/, sane.inner_html
   end
 
   def test_css_flex_wrap
     html = '<div style="flex-wrap:wrap;"></div>'
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/flex-wrap:wrap/, sane.inner_html
   end
 
   def test_css_justify_content
     html = '<div style="justify-content:flex-start;"></div>'
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/justify-content:flex-start/, sane.inner_html
   end
 
   def test_css_order
     html = '<div style="order:5;"></div>'
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
     assert_match %r/order:5/, sane.inner_html
   end
 
   def test_upper_case_css_property
     html = "<div style=\"COLOR: BLUE; NOTAPROPERTY: RED;\">asdf</div>"
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :strip).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :strip).to_xml)
     assert_match(/COLOR:\s*BLUE/i, sane.at_css("div")["style"])
     refute_match(/NOTAPROPERTY/i, sane.at_css("div")["style"])
   end
 
   def test_many_properties_some_allowed
     html = "<div style=\"background: bold notaproperty center alsonotaproperty 10px;\">asdf</div>"
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :strip).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :strip).to_xml)
     assert_match(/bold\s+center\s+10px/, sane.at_css("div")["style"])
   end
 
   def test_many_properties_non_allowed
     html = "<div style=\"background: notaproperty alsonotaproperty;\">asdf</div>"
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :strip).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :strip).to_xml)
     assert_nil sane.at_css("div")["style"]
   end
 
   def test_svg_properties
     html = "<line style='stroke-width: 10px;'></line>"
-    sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :strip).to_xml)
+    sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :strip).to_xml)
     assert_match(/stroke-width:\s*10px/, sane.at_css("line")["style"])
   end
 end

--- a/test/html5/test_sanitizer.rb
+++ b/test/html5/test_sanitizer.rb
@@ -264,7 +264,6 @@ class Html5TestSanitizer < Loofah::TestCase
     JSON::parse(open(filename).read).each do |test|
       it "testdata sanitizer #{test["name"]}" do
         test.delete("name")
-        test.delete("commentary")
         input = test.delete("input")
         outputs = test.keys.sort.map { |k| test[k] }
         check_sanitization(input, *outputs)

--- a/test/integration/test_ad_hoc.rb
+++ b/test/integration/test_ad_hoc.rb
@@ -1,6 +1,8 @@
 require "helper"
 
 class IntegrationTestAdHoc < Loofah::TestCase
+  MSWORD_HTML = File.read(File.join(File.dirname(__FILE__), "..", "assets", "msword.html")).freeze
+
   LOOFAH_HTML_VERSIONS.each do |html_version|
     describe "ad hoc #{html_version}" do
       let(:html_version) { html_version }
@@ -45,8 +47,6 @@ class IntegrationTestAdHoc < Loofah::TestCase
       end
 
       context "tests" do
-        MSWORD_HTML = File.read(File.join(File.dirname(__FILE__), "..", "assets", "msword.html")).freeze
-
         def test_removal_of_illegal_tag
           html = <<~HTML
             following this there should be no jim tag

--- a/test/integration/test_ad_hoc.rb
+++ b/test/integration/test_ad_hoc.rb
@@ -1,388 +1,430 @@
 require "helper"
 
 class IntegrationTestAdHoc < Loofah::TestCase
-  context "blank input string" do
-    context "fragment" do
-      it "return a blank string" do
-        assert_equal "", Loofah.scrub_html4_fragment("", :prune).to_s
+  ["html4", "html5"].each do |html_version|
+    describe "ad hoc #{html_version}" do
+      let(:html_version) { html_version }
+
+      def fragment(*args)
+        Loofah.send("#{html_version}_fragment", *args)
       end
-    end
 
-    context "document" do
-      it "return a blank string" do
-        assert_equal "", Loofah.scrub_html4_document("", :prune).root.to_s
+      def document(*args)
+        Loofah.send("#{html_version}_document", *args)
       end
-    end
-  end
 
-  context "tests" do
-    MSWORD_HTML = File.read(File.join(File.dirname(__FILE__), "..", "assets", "msword.html")).freeze
-
-    def test_removal_of_illegal_tag
-      html = <<-HTML
-      following this there should be no jim tag
-      <jim>jim</jim>
-      was there?
-    HTML
-      sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
-      assert sane.xpath("//jim").empty?
-    end
-
-    def test_removal_of_illegal_attribute
-      html = "<p class=bar foo=bar abbr=bar />"
-      sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
-      node = sane.xpath("//p").first
-      assert node.attributes["class"]
-      assert node.attributes["abbr"]
-      assert_nil node.attributes["foo"]
-    end
-
-    def test_removal_of_illegal_url_in_href
-      html = <<-HTML
-      <a href='jimbo://jim.jim/'>this link should have its href removed because of illegal url</a>
-      <a href='http://jim.jim/'>this link should be fine</a>
-    HTML
-      sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
-      nodes = sane.xpath("//a")
-      assert_nil nodes.first.attributes["href"]
-      assert nodes.last.attributes["href"]
-    end
-
-    def test_css_sanitization
-      html = "<p style='background-color: url(\"http://foo.com/\") ; background-color: #000 ;' />"
-      sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
-      assert_match %r/#000/, sane.inner_html
-      refute_match %r/foo\.com/, sane.inner_html
-    end
-
-    def test_fragment_with_no_tags
-      assert_equal "This fragment has no tags.", Loofah.scrub_html4_fragment("This fragment has no tags.", :escape).to_xml
-    end
-
-    def test_fragment_in_p_tag
-      assert_equal "<p>This fragment is in a p.</p>", Loofah.scrub_html4_fragment("<p>This fragment is in a p.</p>", :escape).to_xml
-    end
-
-    def test_fragment_in_p_tag_plus_stuff
-      assert_equal "<p>This fragment is in a p.</p>foo<strong>bar</strong>", Loofah.scrub_html4_fragment("<p>This fragment is in a p.</p>foo<strong>bar</strong>", :escape).to_xml
-    end
-
-    def test_fragment_with_text_nodes_leading_and_trailing
-      assert_equal "text<p>fragment</p>text", Loofah.scrub_html4_fragment("text<p>fragment</p>text", :escape).to_xml
-    end
-
-    def test_whitewash_on_fragment
-      html = "safe<frameset rows=\"*\"><frame src=\"http://example.com\"></frameset> <b>description</b>"
-      whitewashed = Loofah.scrub_html4_document(html, :whitewash).xpath("/html/body/*").to_s
-      assert_equal "<p>safe</p><b>description</b>", whitewashed.gsub("\n", "")
-    end
-
-    def test_fragment_whitewash_on_microsofty_markup
-      whitewashed = Loofah.html4_fragment(MSWORD_HTML).scrub!(:whitewash)
-      if Nokogiri.uses_libxml?("<2.9.11")
-        assert_equal "<p>Foo <b>BOLD</b></p>", whitewashed.to_s.strip
-      else
-        assert_equal "<p>Foo <b>BOLD<p></p></b></p>", whitewashed.to_s.strip
+      def scrub_fragment(*args)
+        Loofah.send("scrub_#{html_version}_fragment", *args)
       end
-    end
 
-    def test_document_whitewash_on_microsofty_markup
-      whitewashed = Loofah.html4_document(MSWORD_HTML).scrub!(:whitewash)
-      if Nokogiri.uses_libxml?("<2.9.11")
-        assert_equal "<p>Foo <b>BOLD</b></p>", whitewashed.xpath("/html/body/*").to_s
-      else
-        assert_equal "<p>Foo <b>BOLD<p></p></b></p>", whitewashed.xpath("/html/body/*").to_s
+      def scrub_document(*args)
+        Loofah.send("scrub_#{html_version}_document", *args)
       end
-    end
 
-    def test_return_empty_string_when_nothing_left
-      assert_equal "", Loofah.scrub_html4_document("<script>test</script>", :prune).text
-    end
-
-    def test_nested_script_cdata_tags_should_be_scrubbed
-      html = "<script><script src=\"malicious.js\">this & that</script>"
-      stripped = Loofah.html4_fragment(html).scrub!(:strip)
-
-      assert_empty stripped.xpath("//script")
-      assert_equal("&lt;script src=\"malicious.js\"&gt;this &amp; that", stripped.to_html)
-    end
-
-    def test_nested_script_cdata_tags_should_be_scrubbed_2
-      html = "<script><script>alert('a');</script></script>"
-      stripped = Loofah.html4_fragment(html).scrub!(:strip)
-
-      assert_empty stripped.xpath("//script")
-      assert_equal("&lt;script&gt;alert('a');", stripped.to_html)
-    end
-
-    def test_nested_script_cdata_tags_should_be_scrubbed_max_recursion
-      n = 40
-      html = "<div>" + ("<script>" * n) + "alert(1);" + ("</script>" * n) + "</div>"
-      expected = "<div>" + ("&lt;script&gt;" * (n-1)) + "alert(1);</div>"
-      actual = Loofah.html4_fragment(html).scrub!(:strip).to_html
-
-      assert_equal(expected, actual)
-    end
-
-    def test_removal_of_all_tags
-      html = <<-HTML
-      What's up <strong>doc</strong>?
-    HTML
-      stripped = Loofah.scrub_html4_document(html, :prune).text
-      assert_equal %Q(What\'s up doc?).strip, stripped.strip
-    end
-
-    def test_dont_remove_whitespace
-      html = "Foo\nBar"
-      assert_equal html, Loofah.scrub_html4_document(html, :prune).text
-    end
-
-    def test_dont_remove_whitespace_between_tags
-      html = "<p>Foo</p>\n<p>Bar</p>"
-      assert_equal "Foo\nBar", Loofah.scrub_html4_document(html, :prune).text
-    end
-
-    #
-    #  tests for CVE-2018-8048 (see https://github.com/flavorjones/loofah/issues/144)
-    #
-    #  libxml2 >= 2.9.2 fails to escape comments within some attributes. It
-    #  wants to ensure these comments can be treated as "server-side includes",
-    #  but as a result fails to ensure that serialization is well-formed,
-    #  resulting in an opportunity for XSS injection of code into a final
-    #  re-parsed document (presumably in a browser).
-    #
-    #  we'll test this by parsing the HTML, serializing it, then
-    #  re-parsing it to ensure there isn't any ambiguity in the output
-    #  that might allow code injection into a browser consuming
-    #  "sanitized" output.
-    #
-    [
-      #
-      #  these tags and attributes are determined by the code at:
-      #
-      #    https://git.gnome.org/browse/libxml2/tree/HTMLtree.c?h=v2.9.2#n714
-      #
-      { tag: "a", attr: "href" },
-      { tag: "div", attr: "href" },
-      { tag: "a", attr: "action" },
-      { tag: "div", attr: "action" },
-      { tag: "a", attr: "src" },
-      { tag: "div", attr: "src" },
-      { tag: "a", attr: "name" },
-      #
-      #  note that div+name is _not_ affected by the libxml2 issue.
-      #  but we test it anyway to ensure our logic isn't modifying
-      #  attributes that don't need modifying.
-      #
-      { tag: "div", attr: "name", unescaped: true },
-    ].each do |config|
-      define_method "test_uri_escaping_of_#{config[:attr]}_attr_in_#{config[:tag]}_tag" do
-        html = %{<#{config[:tag]} #{config[:attr]}='examp<!--" unsafeattr=foo()>-->le.com'>test</#{config[:tag]}>}
-
-        reparsed = Loofah.html4_fragment(Loofah.html4_fragment(html).scrub!(:prune).to_html)
-        attributes = reparsed.at_css(config[:tag]).attribute_nodes
-
-        assert_equal [config[:attr]], attributes.collect(&:name)
-        if Nokogiri::VersionInfo.instance.libxml2?
-          if config[:unescaped]
-            #
-            #  this attribute was emitted wrapped in single-quotes, so a double quote is A-OK.
-            #  assert that this attribute's serialization is unaffected.
-            #
-            assert_equal %{examp<!--" unsafeattr=foo()>-->le.com}, attributes.first.value
-          else
-            #
-            #  let's match the behavior in libxml < 2.9.2.
-            #  test that this attribute's serialization is well-formed and sanitized.
-            #
-            assert_equal %{examp<!--%22%20unsafeattr=foo()>-->le.com}, attributes.first.value
+      context "blank input string" do
+        context "fragment" do
+          it "return a blank string" do
+            assert_equal "", scrub_fragment("", :prune).to_s
           end
-        else
+        end
+
+        context "document" do
+          if html_version == "html5"
+            it "returns a document with an empty head and body" do
+              assert_equal(
+                "<html><head></head><body></body></html>",
+                scrub_document("", :prune).root.to_s,
+              )
+            end
+          else
+            it "return a blank string" do
+              assert_equal("", scrub_document("", :prune).root.to_s)
+            end
+          end
+        end
+      end
+
+      context "tests" do
+        MSWORD_HTML = File.read(File.join(File.dirname(__FILE__), "..", "assets", "msword.html")).freeze
+
+        def test_removal_of_illegal_tag
+          html = <<~HTML
+            following this there should be no jim tag
+            <jim>jim</jim>
+            was there?
+          HTML
+          sane = Nokogiri::HTML(scrub_fragment(html, :escape).to_xml)
+          assert sane.xpath("//jim").empty?
+        end
+
+        def test_removal_of_illegal_attribute
+          html = "<p class=bar foo=bar abbr=bar />"
+          sane = Nokogiri::HTML(scrub_fragment(html, :escape).to_xml)
+          node = sane.xpath("//p").first
+          assert node.attributes["class"]
+          assert node.attributes["abbr"]
+          assert_nil node.attributes["foo"]
+        end
+
+        def test_removal_of_illegal_url_in_href
+          html = <<~HTML
+            <a href='jimbo://jim.jim/'>this link should have its href removed because of illegal url</a>
+            <a href='http://jim.jim/'>this link should be fine</a>
+          HTML
+          sane = Nokogiri::HTML(scrub_fragment(html, :escape).to_xml)
+          nodes = sane.xpath("//a")
+          assert_nil nodes.first.attributes["href"]
+          assert nodes.last.attributes["href"]
+        end
+
+        def test_css_sanitization
+          html = "<p style='background-color: url(\"http://foo.com/\") ; background-color: #000 ;' />"
+          sane = Nokogiri::HTML(scrub_fragment(html, :escape).to_xml)
+          assert_match %r/#000/, sane.inner_html
+          refute_match %r/foo\.com/, sane.inner_html
+        end
+
+        def test_fragment_with_no_tags
+          assert_equal "This fragment has no tags.", scrub_fragment("This fragment has no tags.", :escape).to_xml
+        end
+
+        def test_fragment_in_p_tag
+          assert_equal "<p>This fragment is in a p.</p>", scrub_fragment("<p>This fragment is in a p.</p>", :escape).to_xml
+        end
+
+        def test_fragment_in_p_tag_plus_stuff
+          assert_equal "<p>This fragment is in a p.</p>foo<strong>bar</strong>", scrub_fragment("<p>This fragment is in a p.</p>foo<strong>bar</strong>", :escape).to_xml
+        end
+
+        def test_fragment_with_text_nodes_leading_and_trailing
+          assert_equal "text<p>fragment</p>text", scrub_fragment("text<p>fragment</p>text", :escape).to_xml
+        end
+
+        def test_whitewash_on_fragment
+          html = "safe<frameset rows=\"*\"><frame src=\"http://example.com\"></frameset> <b>description</b>"
+          whitewashed = scrub_document(html, :whitewash).xpath("/html/body")
+          expected = if html_version == "html4"
+            "<body><p>safe</p> <b>description</b></body>"
+          else
+            "<body>safe <b>description</b></body>"
+          end
+
+          assert_equal(expected, whitewashed.to_s.gsub("\n", ""))
+        end
+
+        def test_fragment_whitewash_on_microsofty_markup
+          whitewashed = fragment(MSWORD_HTML).scrub!(:whitewash)
+          if Nokogiri.uses_libxml?("<2.9.11") || html_version == "html5"
+            assert_equal "<p>Foo <b>BOLD</b></p>", whitewashed.to_s.strip
+          else
+            assert_equal "<p>Foo <b>BOLD<p></p></b></p>", whitewashed.to_s.strip
+          end
+        end
+
+        def test_document_whitewash_on_microsofty_markup
+          whitewashed = document(MSWORD_HTML).scrub!(:whitewash)
+          if Nokogiri.uses_libxml?("<2.9.11") || html_version == "html5"
+            assert_equal "<p>Foo <b>BOLD</b></p>", whitewashed.xpath("/html/body/*").to_s
+          else
+            assert_equal "<p>Foo <b>BOLD<p></p></b></p>", whitewashed.xpath("/html/body/*").to_s
+          end
+        end
+
+        def test_return_empty_string_when_nothing_left
+          assert_equal "", scrub_document("<script>test</script>", :prune).text
+        end
+
+        def test_nested_script_cdata_tags_should_be_scrubbed
+          html = "<script><script src=\"malicious.js\">this & that</script>"
+          stripped = fragment(html).scrub!(:strip)
+
+          assert_empty stripped.xpath("//script")
+          assert_equal("&lt;script src=\"malicious.js\"&gt;this &amp; that", stripped.to_html)
+        end
+
+        def test_nested_script_cdata_tags_should_be_scrubbed_2
+          html = "<script><script>alert('a');</script></script>"
+          stripped = fragment(html).scrub!(:strip)
+
+          assert_empty stripped.xpath("//script")
+          assert_equal("&lt;script&gt;alert('a');", stripped.to_html)
+        end
+
+        def test_nested_script_cdata_tags_should_be_scrubbed_max_recursion
+          n = 40
+          html = "<div>" + ("<script>" * n) + "alert(1);" + ("</script>" * n) + "</div>"
+          expected = "<div>" + ("&lt;script&gt;" * (n-1)) + "alert(1);</div>"
+          actual = fragment(html).scrub!(:strip).to_html
+
+          assert_equal(expected, actual)
+        end
+
+        def test_removal_of_all_tags
+          html = <<~HTML
+            What's up <strong>doc</strong>?
+          HTML
+          stripped = scrub_document(html, :prune).text
+          assert_equal %Q(What\'s up doc?).strip, stripped.strip
+        end
+
+        def test_dont_remove_whitespace
+          html = "Foo\nBar"
+          assert_equal html, scrub_document(html, :prune).text
+        end
+
+        def test_dont_remove_whitespace_between_tags
+          html = "<p>Foo</p>\n<p>Bar</p>"
+          assert_equal "Foo\nBar", scrub_document(html, :prune).text
+        end
+
+        #
+        #  tests for CVE-2018-8048 (see https://github.com/flavorjones/loofah/issues/144)
+        #
+        #  libxml2 >= 2.9.2 fails to escape comments within some attributes. It
+        #  wants to ensure these comments can be treated as "server-side includes",
+        #  but as a result fails to ensure that serialization is well-formed,
+        #  resulting in an opportunity for XSS injection of code into a final
+        #  re-parsed document (presumably in a browser).
+        #
+        #  we'll test this by parsing the HTML, serializing it, then
+        #  re-parsing it to ensure there isn't any ambiguity in the output
+        #  that might allow code injection into a browser consuming
+        #  "sanitized" output.
+        #
+        [
           #
-          #  yay for consistency in javaland. move along, nothing to see here.
+          #  these tags and attributes are determined by the code at:
           #
-          assert_equal %{examp<!--%22 unsafeattr=foo()>-->le.com}, attributes.first.value
-        end
-      end
-    end
+          #    https://git.gnome.org/browse/libxml2/tree/HTMLtree.c?h=v2.9.2#n714
+          #
+          { tag: "a", attr: "href" },
+          { tag: "div", attr: "href" },
+          { tag: "a", attr: "action" },
+          { tag: "div", attr: "action" },
+          { tag: "a", attr: "src" },
+          { tag: "div", attr: "src" },
+          { tag: "a", attr: "name" },
+          #
+          #  note that div+name is _not_ affected by the libxml2 issue.
+          #  but we test it anyway to ensure our logic isn't modifying
+          #  attributes that don't need modifying.
+          #
+          { tag: "div", attr: "name", unescaped: true },
+        ].each do |config|
+          define_method "test_uri_escaping_of_#{config[:attr]}_attr_in_#{config[:tag]}_tag" do
+            html = %{<#{config[:tag]} #{config[:attr]}='examp<!--" unsafeattr=foo()>-->le.com'>test</#{config[:tag]}>}
 
-    it "allows aria attributes" do
-      html = <<~HTML
-        <div role="application" aria-label="calendar"
-             aria-description="Game schedule for the Boston Red Sox 2021 Season">
-          <h1>Red Sox 2021</h1>
-        </div>
-      HTML
+            reparsed = fragment(fragment(html).scrub!(:prune).to_html)
+            attributes = reparsed.at_css(config[:tag]).attribute_nodes
 
-      sanitized = Loofah.scrub_html4_fragment(html, :escape)
-      attributes = sanitized.at_css("div").attributes
-      assert_includes(attributes.keys, "role")
-      assert_includes(attributes.keys, "aria-label")
-      assert_includes(attributes.keys, "aria-description")
-    end
-
-    context "xss protection from svg animate attributes" do
-      # see recommendation from https://html5sec.org/#137
-      # to sanitize "to", "from", "values", and "by" attributes
-
-      it "sanitizes 'from', 'to', and 'by' attributes" do
-        # for CVE-2018-16468
-        # see:
-        # - https://github.com/flavorjones/loofah/issues/154
-        # - https://hackerone.com/reports/429267
-        html = %Q{<svg><a xmlns:xlink=http://www.w3.org/1999/xlink xlink:href=?><circle r=400 /><animate attributeName=xlink:href begin=0 from=javascript:alert(1) to=%26 by=5>}
-
-        sanitized = Loofah.scrub_html4_fragment(html, :escape)
-        assert_nil sanitized.at_css("animate")["from"]
-        assert_nil sanitized.at_css("animate")["to"]
-        assert_nil sanitized.at_css("animate")["by"]
-      end
-
-      it "sanitizes 'values' attribute" do
-        # for CVE-2019-15587
-        # see:
-        # - https://github.com/flavorjones/loofah/issues/171
-        # - https://hackerone.com/reports/709009
-        html = %Q{<svg> <animate href="#foo" attributeName="href" values="javascript:alert('xss')"/> <a id="foo"> <circle r=400 /> </a> </svg>}
-
-        sanitized = Loofah.scrub_html4_fragment(html, :escape)
-        assert_nil sanitized.at_css("animate")["values"]
-      end
-    end
-
-    #
-    #  brought up by https://github.com/flavorjones/loofah/issues/80
-    #
-    context "comments outside html" do
-      context "bare comments" do
-        let(:html) { "<!-- --!><script>alert(1)</script><!-- -->" }
-
-        it "Loofah.html4_document removes the comment" do
-          sanitized = Loofah.html4_document(html)
-          refute(sanitized.children.any? { |node| node.comment? } )
+            assert_equal [config[:attr]], attributes.collect(&:name)
+            if Nokogiri::VersionInfo.instance.libxml2?
+              if config[:unescaped]
+                #
+                #  this attribute was emitted wrapped in single-quotes, so a double quote is A-OK.
+                #  assert that this attribute's serialization is unaffected.
+                #
+                assert_equal %{examp<!--" unsafeattr=foo()>-->le.com}, attributes.first.value
+              else
+                #
+                #  let's match the behavior in libxml < 2.9.2.
+                #  test that this attribute's serialization is well-formed and sanitized.
+                #
+                assert_equal %{examp<!--%22%20unsafeattr=foo()>-->le.com}, attributes.first.value
+              end
+            else
+              #
+              #  yay for consistency in javaland. move along, nothing to see here.
+              #
+              assert_equal %{examp<!--%22 unsafeattr=foo()>-->le.com}, attributes.first.value
+            end
+          end
         end
 
-        it "Loofah.scrub_html4_document removes the comment" do
-          sanitized = Loofah.scrub_html4_document(html, :prune)
-          sanitized_html = sanitized.to_html
-          refute_match(/--/, sanitized_html)
-        end
-      end
+        it "allows aria attributes" do
+          html = <<~HTML
+            <div role="application" aria-label="calendar"
+                 aria-description="Game schedule for the Boston Red Sox 2021 Season">
+              <h1>Red Sox 2021</h1>
+            </div>
+          HTML
 
-      context "doc with comments outside HTML" do
-        let(:html) do
-          <<~EOF
-            <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
-                <!-- spaces ->
-            		<!-- tabs -->
-                     <!-- more spaces -->
-            <html><body><div>hello
-          EOF
+          sanitized = scrub_fragment(html, :escape)
+          attributes = sanitized.at_css("div").attributes
+          assert_includes(attributes.keys, "role")
+          assert_includes(attributes.keys, "aria-label")
+          assert_includes(attributes.keys, "aria-description")
         end
 
-        it "Loofah.html4_document removes the comment" do
-          sanitized = Loofah.html4_document(html)
-          sanitized_html = sanitized.to_html
-          refute_match(/--/, sanitized_html)
+        context "xss protection from svg animate attributes" do
+          # see recommendation from https://html5sec.org/#137
+          # to sanitize "to", "from", "values", and "by" attributes
+
+          it "sanitizes 'from', 'to', and 'by' attributes" do
+            # for CVE-2018-16468
+            # see:
+            # - https://github.com/flavorjones/loofah/issues/154
+            # - https://hackerone.com/reports/429267
+            html = %Q{<svg><a xmlns:xlink=http://www.w3.org/1999/xlink xlink:href=?><circle r=400 /><animate attributeName=xlink:href begin=0 from=javascript:alert(1) to=%26 by=5>}
+
+            sanitized = scrub_fragment(html, :escape)
+            assert_nil sanitized.at_css("animate")["from"]
+            assert_nil sanitized.at_css("animate")["to"]
+            assert_nil sanitized.at_css("animate")["by"]
+          end
+
+          it "sanitizes 'values' attribute" do
+            # for CVE-2019-15587
+            # see:
+            # - https://github.com/flavorjones/loofah/issues/171
+            # - https://hackerone.com/reports/709009
+            html = %Q{<svg> <animate href="#foo" attributeName="href" values="javascript:alert('xss')"/> <a id="foo"> <circle r=400 /> </a> </svg>}
+
+            sanitized = scrub_fragment(html, :escape)
+            assert_nil sanitized.at_css("animate")["values"]
+          end
         end
 
-        it "Loofah.scrub_html4_document removes the comment" do
-          sanitized = Loofah.scrub_html4_document(html, :prune)
-          sanitized_html = sanitized.to_html
-          refute_match(/--/, sanitized_html)
+        #
+        #  brought up by https://github.com/flavorjones/loofah/issues/80
+        #
+        context "comments outside html" do
+          context "bare comments" do
+            let(:html) { "<!-- --!><script>alert(1)</script><!-- -->" }
+
+            it "document removes the comment" do
+              sanitized = document(html)
+              refute(sanitized.children.any? { |node| node.comment? } )
+            end
+
+            it "scrub_document removes the comment" do
+              sanitized = scrub_document(html, :prune)
+              sanitized_html = sanitized.to_html
+              refute_match(/--/, sanitized_html)
+            end
+          end
+
+          context "doc with comments outside HTML" do
+            let(:html) do
+              <<~HTML
+                <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+                    <!-- spaces ->
+                    <!-- tabs -->
+                         <!-- more spaces -->
+                <html><body><div>hello
+              HTML
+            end
+
+            it "document removes the comment" do
+              sanitized = document(html)
+              sanitized_html = sanitized.to_html
+              refute_match(/--/, sanitized_html)
+            end
+
+            it "scrub_document removes the comment" do
+              sanitized = scrub_document(html, :prune)
+              sanitized_html = sanitized.to_html
+              refute_match(/--/, sanitized_html)
+            end
+          end
         end
-      end
-    end
 
-    it "handles property string values" do
-      input = <<~EOF
-        <span style="font-size: 36px; font-family: 'AvenirNext-Regular';">variation 1a</span>
-        <span style="font-size: 36px; font-family: AvenirNext-Regular;">variation 1b</span>
-        <span style="font-size: 36px; font-family: 'Avenir Next';">variation 2a</span>
-        <span style="font-size: 36px; font-family: Avenir Next;">variation 2b</span>
-      EOF
+        it "handles property string values" do
+          input = <<~HTML
+            <span style="font-size: 36px; font-family: 'AvenirNext-Regular';">variation 1a</span>
+            <span style="font-size: 36px; font-family: AvenirNext-Regular;">variation 1b</span>
+            <span style="font-size: 36px; font-family: 'Avenir Next';">variation 2a</span>
+            <span style="font-size: 36px; font-family: Avenir Next;">variation 2b</span>
+          HTML
 
-      expected = <<~EOF
-        <span style="font-size:36px;font-family:'AvenirNext-Regular';">variation 1a</span>
-        <span style="font-size:36px;font-family:AvenirNext-Regular;">variation 1b</span>
-        <span style="font-size:36px;font-family:'Avenir Next';">variation 2a</span>
-        <span style="font-size:36px;font-family:Avenir Next;">variation 2b</span>
-      EOF
+          expected = <<~HTML
+            <span style="font-size:36px;font-family:'AvenirNext-Regular';">variation 1a</span>
+            <span style="font-size:36px;font-family:AvenirNext-Regular;">variation 1b</span>
+            <span style="font-size:36px;font-family:'Avenir Next';">variation 2a</span>
+            <span style="font-size:36px;font-family:Avenir Next;">variation 2b</span>
+          HTML
 
-      actual = Loofah.scrub_html4_fragment(input, :escape)
+          actual = scrub_fragment(input, :escape)
 
-      assert_equal(expected, actual.to_html)
-    end
+          assert_equal(expected, actual.to_html)
+        end
 
-    it "allows border-collapse property values" do
-      # https://github.com/flavorjones/loofah/issues/201
-      # https://developer.mozilla.org/en-US/docs/Web/CSS/border-collapse
-      input = <<~EOF
-        <table style='border-collapse: collapse;'></table>
-        <table style='border-collapse: separate;'></table>
-        <table style='border-collapse: not-allowed;'></table>
-        <table style='border-collapse: inherit;'></table>
-        <table style='border-collapse: initial;'></table>
-        <table style='border-collapse: revert;'></table>
-        <table style='border-collapse: unset;'></table>
-      EOF
+        it "allows border-collapse property values" do
+          # https://github.com/flavorjones/loofah/issues/201
+          # https://developer.mozilla.org/en-US/docs/Web/CSS/border-collapse
+          input = <<~HTML
+            <table style='border-collapse: collapse;'></table>
+            <table style='border-collapse: separate;'></table>
+            <table style='border-collapse: not-allowed;'></table>
+            <table style='border-collapse: inherit;'></table>
+            <table style='border-collapse: initial;'></table>
+            <table style='border-collapse: revert;'></table>
+            <table style='border-collapse: unset;'></table>
+          HTML
 
-      expected = <<~EOF
-        <table style=\"border-collapse:collapse;\"></table>
-        <table style=\"border-collapse:separate;\"></table>
-        <table></table>
-        <table style=\"border-collapse:inherit;\"></table>
-        <table style=\"border-collapse:initial;\"></table>
-        <table style=\"border-collapse:revert;\"></table>
-        <table style=\"border-collapse:unset;\"></table>
-      EOF
+          expected = <<~HTML
+            <table style=\"border-collapse:collapse;\"></table>
+            <table style=\"border-collapse:separate;\"></table>
+            <table></table>
+            <table style=\"border-collapse:inherit;\"></table>
+            <table style=\"border-collapse:initial;\"></table>
+            <table style=\"border-collapse:revert;\"></table>
+            <table style=\"border-collapse:unset;\"></table>
+          HTML
 
-      actual = Loofah.scrub_html4_fragment(input, :escape)
+          actual = scrub_fragment(input, :escape)
 
-      assert_equal(expected, actual.to_html)
-    end
+          assert_equal(expected, actual.to_html)
+        end
 
-    describe "entities" do
-      it "handles & character" do
-        input = %{<div> this & that </div>}
-        expected = %{<div> this &amp; that </div>}
-        actual = Loofah.scrub_html4_fragment(input, :escape)
-        assert_equal(expected, actual.to_html)
-      end
+        describe "entities" do
+          it "handles & character" do
+            input = %{<div> this & that </div>}
+            expected = %{<div> this &amp; that </div>}
+            actual = scrub_fragment(input, :escape)
+            assert_equal(expected, actual.to_html)
+          end
 
-      it "handles > character" do
-        input = %{<div> this > that </div>}
-        expected = %{<div> this &gt; that </div>}
-        actual = Loofah.scrub_html4_fragment(input, :escape)
-        assert_equal(expected, actual.to_html)
-      end
+          it "handles > character" do
+            input = %{<div> this > that </div>}
+            expected = %{<div> this &gt; that </div>}
+            actual = scrub_fragment(input, :escape)
+            assert_equal(expected, actual.to_html)
+          end
 
-      it "handles < character" do
-        input = %{<div> this < that </div>}
-        expected = %{<div> this &lt; that </div>}
-        actual = Loofah.scrub_html4_fragment(input, :escape)
-        assert_equal(expected, actual.to_html)
-      end
+          it "handles < character" do
+            input = %{<div> this < that </div>}
+            expected = %{<div> this &lt; that </div>}
+            actual = scrub_fragment(input, :escape)
+            assert_equal(expected, actual.to_html)
+          end
 
-      it "handles < character in an attribute" do
-        input = %{<div alt="this < that">wave</div>}
-        expected = %{<div alt="this &lt; that">wave</div>}
-        actual = Loofah.scrub_html4_fragment(input, :escape)
-        assert_equal(expected, actual.to_html)
-      end
+          it "handles < character in an attribute" do
+            input = %{<div alt="this < that">wave</div>}
+            expected = if html_version == "html4"
+              %{<div alt="this &lt; that">wave</div>}
+            else
+              %{<div alt="this < that">wave</div>}
+            end
+            actual = scrub_fragment(input, :escape)
 
-      it "handles multiple < characters" do
-        input = %{<div> this <<</div>}
-        expected = %{<div> this &lt;&lt;</div>}
-        actual = Loofah.scrub_html4_fragment(input, :escape)
-        assert_equal(expected, actual.to_html)
-      end
+            assert_equal(expected, actual.to_html)
+          end
 
-      it "handles &lt; entity" do
-        input = %{<div> this &lt; that </div>}
-        expected = input
-        actual = Loofah.scrub_html4_fragment(input, :escape)
-        assert_equal(expected, actual.to_html)
+          it "handles multiple < characters" do
+            input = %{<div> this <<</div>}
+            expected = %{<div> this &lt;&lt;</div>}
+            actual = scrub_fragment(input, :escape)
+            assert_equal(expected, actual.to_html)
+          end
+
+          it "handles &lt; entity" do
+            input = %{<div> this &lt; that </div>}
+            expected = input
+            actual = scrub_fragment(input, :escape)
+            assert_equal(expected, actual.to_html)
+          end
+        end
       end
     end
   end

--- a/test/integration/test_ad_hoc.rb
+++ b/test/integration/test_ad_hoc.rb
@@ -4,13 +4,13 @@ class IntegrationTestAdHoc < Loofah::TestCase
   context "blank input string" do
     context "fragment" do
       it "return a blank string" do
-        assert_equal "", Loofah.scrub_fragment("", :prune).to_s
+        assert_equal "", Loofah.scrub_html4_fragment("", :prune).to_s
       end
     end
 
     context "document" do
       it "return a blank string" do
-        assert_equal "", Loofah.scrub_document("", :prune).root.to_s
+        assert_equal "", Loofah.scrub_html4_document("", :prune).root.to_s
       end
     end
   end
@@ -24,13 +24,13 @@ class IntegrationTestAdHoc < Loofah::TestCase
       <jim>jim</jim>
       was there?
     HTML
-      sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+      sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
       assert sane.xpath("//jim").empty?
     end
 
     def test_removal_of_illegal_attribute
       html = "<p class=bar foo=bar abbr=bar />"
-      sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+      sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
       node = sane.xpath("//p").first
       assert node.attributes["class"]
       assert node.attributes["abbr"]
@@ -42,7 +42,7 @@ class IntegrationTestAdHoc < Loofah::TestCase
       <a href='jimbo://jim.jim/'>this link should have its href removed because of illegal url</a>
       <a href='http://jim.jim/'>this link should be fine</a>
     HTML
-      sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+      sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
       nodes = sane.xpath("//a")
       assert_nil nodes.first.attributes["href"]
       assert nodes.last.attributes["href"]
@@ -50,35 +50,35 @@ class IntegrationTestAdHoc < Loofah::TestCase
 
     def test_css_sanitization
       html = "<p style='background-color: url(\"http://foo.com/\") ; background-color: #000 ;' />"
-      sane = Nokogiri::HTML(Loofah.scrub_fragment(html, :escape).to_xml)
+      sane = Nokogiri::HTML(Loofah.scrub_html4_fragment(html, :escape).to_xml)
       assert_match %r/#000/, sane.inner_html
       refute_match %r/foo\.com/, sane.inner_html
     end
 
     def test_fragment_with_no_tags
-      assert_equal "This fragment has no tags.", Loofah.scrub_fragment("This fragment has no tags.", :escape).to_xml
+      assert_equal "This fragment has no tags.", Loofah.scrub_html4_fragment("This fragment has no tags.", :escape).to_xml
     end
 
     def test_fragment_in_p_tag
-      assert_equal "<p>This fragment is in a p.</p>", Loofah.scrub_fragment("<p>This fragment is in a p.</p>", :escape).to_xml
+      assert_equal "<p>This fragment is in a p.</p>", Loofah.scrub_html4_fragment("<p>This fragment is in a p.</p>", :escape).to_xml
     end
 
     def test_fragment_in_p_tag_plus_stuff
-      assert_equal "<p>This fragment is in a p.</p>foo<strong>bar</strong>", Loofah.scrub_fragment("<p>This fragment is in a p.</p>foo<strong>bar</strong>", :escape).to_xml
+      assert_equal "<p>This fragment is in a p.</p>foo<strong>bar</strong>", Loofah.scrub_html4_fragment("<p>This fragment is in a p.</p>foo<strong>bar</strong>", :escape).to_xml
     end
 
     def test_fragment_with_text_nodes_leading_and_trailing
-      assert_equal "text<p>fragment</p>text", Loofah.scrub_fragment("text<p>fragment</p>text", :escape).to_xml
+      assert_equal "text<p>fragment</p>text", Loofah.scrub_html4_fragment("text<p>fragment</p>text", :escape).to_xml
     end
 
     def test_whitewash_on_fragment
       html = "safe<frameset rows=\"*\"><frame src=\"http://example.com\"></frameset> <b>description</b>"
-      whitewashed = Loofah.scrub_document(html, :whitewash).xpath("/html/body/*").to_s
+      whitewashed = Loofah.scrub_html4_document(html, :whitewash).xpath("/html/body/*").to_s
       assert_equal "<p>safe</p><b>description</b>", whitewashed.gsub("\n", "")
     end
 
     def test_fragment_whitewash_on_microsofty_markup
-      whitewashed = Loofah.fragment(MSWORD_HTML).scrub!(:whitewash)
+      whitewashed = Loofah.html4_fragment(MSWORD_HTML).scrub!(:whitewash)
       if Nokogiri.uses_libxml?("<2.9.11")
         assert_equal "<p>Foo <b>BOLD</b></p>", whitewashed.to_s.strip
       else
@@ -87,7 +87,7 @@ class IntegrationTestAdHoc < Loofah::TestCase
     end
 
     def test_document_whitewash_on_microsofty_markup
-      whitewashed = Loofah.document(MSWORD_HTML).scrub!(:whitewash)
+      whitewashed = Loofah.html4_document(MSWORD_HTML).scrub!(:whitewash)
       if Nokogiri.uses_libxml?("<2.9.11")
         assert_equal "<p>Foo <b>BOLD</b></p>", whitewashed.xpath("/html/body/*").to_s
       else
@@ -96,12 +96,12 @@ class IntegrationTestAdHoc < Loofah::TestCase
     end
 
     def test_return_empty_string_when_nothing_left
-      assert_equal "", Loofah.scrub_document("<script>test</script>", :prune).text
+      assert_equal "", Loofah.scrub_html4_document("<script>test</script>", :prune).text
     end
 
     def test_nested_script_cdata_tags_should_be_scrubbed
       html = "<script><script src=\"malicious.js\">this & that</script>"
-      stripped = Loofah.fragment(html).scrub!(:strip)
+      stripped = Loofah.html4_fragment(html).scrub!(:strip)
 
       assert_empty stripped.xpath("//script")
       assert_equal("&lt;script src=\"malicious.js\"&gt;this &amp; that", stripped.to_html)
@@ -109,7 +109,7 @@ class IntegrationTestAdHoc < Loofah::TestCase
 
     def test_nested_script_cdata_tags_should_be_scrubbed_2
       html = "<script><script>alert('a');</script></script>"
-      stripped = Loofah.fragment(html).scrub!(:strip)
+      stripped = Loofah.html4_fragment(html).scrub!(:strip)
 
       assert_empty stripped.xpath("//script")
       assert_equal("&lt;script&gt;alert('a');", stripped.to_html)
@@ -119,7 +119,7 @@ class IntegrationTestAdHoc < Loofah::TestCase
       n = 40
       html = "<div>" + ("<script>" * n) + "alert(1);" + ("</script>" * n) + "</div>"
       expected = "<div>" + ("&lt;script&gt;" * (n-1)) + "alert(1);</div>"
-      actual = Loofah.fragment(html).scrub!(:strip).to_html
+      actual = Loofah.html4_fragment(html).scrub!(:strip).to_html
 
       assert_equal(expected, actual)
     end
@@ -128,18 +128,18 @@ class IntegrationTestAdHoc < Loofah::TestCase
       html = <<-HTML
       What's up <strong>doc</strong>?
     HTML
-      stripped = Loofah.scrub_document(html, :prune).text
+      stripped = Loofah.scrub_html4_document(html, :prune).text
       assert_equal %Q(What\'s up doc?).strip, stripped.strip
     end
 
     def test_dont_remove_whitespace
       html = "Foo\nBar"
-      assert_equal html, Loofah.scrub_document(html, :prune).text
+      assert_equal html, Loofah.scrub_html4_document(html, :prune).text
     end
 
     def test_dont_remove_whitespace_between_tags
       html = "<p>Foo</p>\n<p>Bar</p>"
-      assert_equal "Foo\nBar", Loofah.scrub_document(html, :prune).text
+      assert_equal "Foo\nBar", Loofah.scrub_html4_document(html, :prune).text
     end
 
     #
@@ -179,7 +179,7 @@ class IntegrationTestAdHoc < Loofah::TestCase
       define_method "test_uri_escaping_of_#{config[:attr]}_attr_in_#{config[:tag]}_tag" do
         html = %{<#{config[:tag]} #{config[:attr]}='examp<!--" unsafeattr=foo()>-->le.com'>test</#{config[:tag]}>}
 
-        reparsed = Loofah.fragment(Loofah.fragment(html).scrub!(:prune).to_html)
+        reparsed = Loofah.html4_fragment(Loofah.html4_fragment(html).scrub!(:prune).to_html)
         attributes = reparsed.at_css(config[:tag]).attribute_nodes
 
         assert_equal [config[:attr]], attributes.collect(&:name)
@@ -214,7 +214,7 @@ class IntegrationTestAdHoc < Loofah::TestCase
         </div>
       HTML
 
-      sanitized = Loofah.scrub_fragment(html, :escape)
+      sanitized = Loofah.scrub_html4_fragment(html, :escape)
       attributes = sanitized.at_css("div").attributes
       assert_includes(attributes.keys, "role")
       assert_includes(attributes.keys, "aria-label")
@@ -232,7 +232,7 @@ class IntegrationTestAdHoc < Loofah::TestCase
         # - https://hackerone.com/reports/429267
         html = %Q{<svg><a xmlns:xlink=http://www.w3.org/1999/xlink xlink:href=?><circle r=400 /><animate attributeName=xlink:href begin=0 from=javascript:alert(1) to=%26 by=5>}
 
-        sanitized = Loofah.scrub_fragment(html, :escape)
+        sanitized = Loofah.scrub_html4_fragment(html, :escape)
         assert_nil sanitized.at_css("animate")["from"]
         assert_nil sanitized.at_css("animate")["to"]
         assert_nil sanitized.at_css("animate")["by"]
@@ -245,7 +245,7 @@ class IntegrationTestAdHoc < Loofah::TestCase
         # - https://hackerone.com/reports/709009
         html = %Q{<svg> <animate href="#foo" attributeName="href" values="javascript:alert('xss')"/> <a id="foo"> <circle r=400 /> </a> </svg>}
 
-        sanitized = Loofah.scrub_fragment(html, :escape)
+        sanitized = Loofah.scrub_html4_fragment(html, :escape)
         assert_nil sanitized.at_css("animate")["values"]
       end
     end
@@ -257,13 +257,13 @@ class IntegrationTestAdHoc < Loofah::TestCase
       context "bare comments" do
         let(:html) { "<!-- --!><script>alert(1)</script><!-- -->" }
 
-        it "Loofah.document removes the comment" do
-          sanitized = Loofah.document(html)
+        it "Loofah.html4_document removes the comment" do
+          sanitized = Loofah.html4_document(html)
           refute(sanitized.children.any? { |node| node.comment? } )
         end
 
-        it "Loofah.scrub_document removes the comment" do
-          sanitized = Loofah.scrub_document(html, :prune)
+        it "Loofah.scrub_html4_document removes the comment" do
+          sanitized = Loofah.scrub_html4_document(html, :prune)
           sanitized_html = sanitized.to_html
           refute_match(/--/, sanitized_html)
         end
@@ -280,14 +280,14 @@ class IntegrationTestAdHoc < Loofah::TestCase
           EOF
         end
 
-        it "Loofah.document removes the comment" do
-          sanitized = Loofah.document(html)
+        it "Loofah.html4_document removes the comment" do
+          sanitized = Loofah.html4_document(html)
           sanitized_html = sanitized.to_html
           refute_match(/--/, sanitized_html)
         end
 
-        it "Loofah.scrub_document removes the comment" do
-          sanitized = Loofah.scrub_document(html, :prune)
+        it "Loofah.scrub_html4_document removes the comment" do
+          sanitized = Loofah.scrub_html4_document(html, :prune)
           sanitized_html = sanitized.to_html
           refute_match(/--/, sanitized_html)
         end
@@ -309,7 +309,7 @@ class IntegrationTestAdHoc < Loofah::TestCase
         <span style="font-size:36px;font-family:Avenir Next;">variation 2b</span>
       EOF
 
-      actual = Loofah.scrub_fragment(input, :escape)
+      actual = Loofah.scrub_html4_fragment(input, :escape)
 
       assert_equal(expected, actual.to_html)
     end
@@ -337,7 +337,7 @@ class IntegrationTestAdHoc < Loofah::TestCase
         <table style=\"border-collapse:unset;\"></table>
       EOF
 
-      actual = Loofah.scrub_fragment(input, :escape)
+      actual = Loofah.scrub_html4_fragment(input, :escape)
 
       assert_equal(expected, actual.to_html)
     end
@@ -346,42 +346,42 @@ class IntegrationTestAdHoc < Loofah::TestCase
       it "handles & character" do
         input = %{<div> this & that </div>}
         expected = %{<div> this &amp; that </div>}
-        actual = Loofah.scrub_fragment(input, :escape)
+        actual = Loofah.scrub_html4_fragment(input, :escape)
         assert_equal(expected, actual.to_html)
       end
 
       it "handles > character" do
         input = %{<div> this > that </div>}
         expected = %{<div> this &gt; that </div>}
-        actual = Loofah.scrub_fragment(input, :escape)
+        actual = Loofah.scrub_html4_fragment(input, :escape)
         assert_equal(expected, actual.to_html)
       end
 
       it "handles < character" do
         input = %{<div> this < that </div>}
         expected = %{<div> this &lt; that </div>}
-        actual = Loofah.scrub_fragment(input, :escape)
+        actual = Loofah.scrub_html4_fragment(input, :escape)
         assert_equal(expected, actual.to_html)
       end
 
       it "handles < character in an attribute" do
         input = %{<div alt="this < that">wave</div>}
         expected = %{<div alt="this &lt; that">wave</div>}
-        actual = Loofah.scrub_fragment(input, :escape)
+        actual = Loofah.scrub_html4_fragment(input, :escape)
         assert_equal(expected, actual.to_html)
       end
 
       it "handles multiple < characters" do
         input = %{<div> this <<</div>}
         expected = %{<div> this &lt;&lt;</div>}
-        actual = Loofah.scrub_fragment(input, :escape)
+        actual = Loofah.scrub_html4_fragment(input, :escape)
         assert_equal(expected, actual.to_html)
       end
 
       it "handles &lt; entity" do
         input = %{<div> this &lt; that </div>}
         expected = input
-        actual = Loofah.scrub_fragment(input, :escape)
+        actual = Loofah.scrub_html4_fragment(input, :escape)
         assert_equal(expected, actual.to_html)
       end
     end

--- a/test/integration/test_html.rb
+++ b/test/integration/test_html.rb
@@ -1,7 +1,7 @@
 require "helper"
 
 class IntegrationTestHtml < Loofah::TestCase
-  ["html4", "html5"].each do |html_version|
+  LOOFAH_HTML_VERSIONS.each do |html_version|
     context "#{html_version} fragment" do
       context "#to_s" do
         it "includes header tags (like style)" do
@@ -12,7 +12,9 @@ class IntegrationTestHtml < Loofah::TestCase
 
           # assumption check is that Nokogiri does the same
           assert_equal(expected, Nokogiri::HTML4::DocumentFragment.parse(html).to_s)
-          assert_equal(expected, Nokogiri::HTML5::DocumentFragment.parse(html).to_s)
+          if Nokogiri.uses_gumbo?
+            assert_equal(expected, Nokogiri::HTML5::DocumentFragment.parse(html).to_s)
+          end
         end
       end
 
@@ -25,7 +27,9 @@ class IntegrationTestHtml < Loofah::TestCase
 
           # assumption check is that Nokogiri does the same
           assert_equal(expected, Nokogiri::HTML4::DocumentFragment.parse(html).text)
-          assert_equal(expected, Nokogiri::HTML5::DocumentFragment.parse(html).text)
+          if Nokogiri.uses_gumbo?
+            assert_equal(expected, Nokogiri::HTML5::DocumentFragment.parse(html).text)
+          end
         end
 
         it "does not include cdata tags (like comments)" do
@@ -36,7 +40,9 @@ class IntegrationTestHtml < Loofah::TestCase
 
           # assumption check is that Nokogiri does the same
           assert_equal(expected, Nokogiri::HTML4::DocumentFragment.parse(html).text)
-          assert_equal(expected, Nokogiri::HTML5::DocumentFragment.parse(html).text)
+          if Nokogiri.uses_gumbo?
+            assert_equal(expected, Nokogiri::HTML5::DocumentFragment.parse(html).text)
+          end
         end
       end
 

--- a/test/integration/test_html.rb
+++ b/test/integration/test_html.rb
@@ -1,98 +1,143 @@
 require "helper"
 
 class IntegrationTestHtml < Loofah::TestCase
-  context "html fragment" do
-    context "#to_s" do
-      it "includes header tags (like style)" do
-        html = "<style>foo</style><div>bar</div>"
-        expected = "<style>foo</style><div>bar</div>"
-        assert_equal(expected, Loofah.html4_fragment(html).to_s)
+  ["html4", "html5"].each do |html_version|
+    context "#{html_version} fragment" do
+      context "#to_s" do
+        it "includes header tags (like style)" do
+          html = "<style>foo</style><div>bar</div>"
+          expected = "<style>foo</style><div>bar</div>"
 
-        # assumption check is that Nokogiri does the same
-        assert_equal(expected, Nokogiri::HTML4::DocumentFragment.parse(html).to_s)
-        assert_equal(expected, Nokogiri::HTML5::DocumentFragment.parse(html).to_s)
+          assert_equal(expected, Loofah.send("#{html_version}_fragment", html).to_s)
+
+          # assumption check is that Nokogiri does the same
+          assert_equal(expected, Nokogiri::HTML4::DocumentFragment.parse(html).to_s)
+          assert_equal(expected, Nokogiri::HTML5::DocumentFragment.parse(html).to_s)
+        end
+      end
+
+      context "#text" do
+        it "includes header tags (like style)" do
+          html = "<style>foo</style><div>bar</div>"
+          expected = "foobar"
+
+          assert_equal(expected, Loofah.send("#{html_version}_fragment", html).text)
+
+          # assumption check is that Nokogiri does the same
+          assert_equal(expected, Nokogiri::HTML4::DocumentFragment.parse(html).text)
+          assert_equal(expected, Nokogiri::HTML5::DocumentFragment.parse(html).text)
+        end
+
+        it "does not include cdata tags (like comments)" do
+          html = "<div>bar<!-- comment1 --></div><!-- comment2 -->"
+          expected = "bar"
+
+          assert_equal(expected, Loofah.send("#{html_version}_fragment", html).text)
+
+          # assumption check is that Nokogiri does the same
+          assert_equal(expected, Nokogiri::HTML4::DocumentFragment.parse(html).text)
+          assert_equal(expected, Nokogiri::HTML5::DocumentFragment.parse(html).text)
+        end
+      end
+
+      context "#to_text" do
+        it "add newlines before and after html4 block elements" do
+          html = Loofah.send(
+            "#{html_version}_fragment",
+            "<div>tweedle<h1>beetle</h1>bottle<span>puddle</span>paddle<div>battle</div>muddle</div>",
+          )
+
+          assert_equal "\ntweedle\nbeetle\nbottlepuddlepaddle\nbattle\nmuddle\n", html.to_text
+        end
+
+        it "add newlines before and after html5 block elements" do
+          html = Loofah.send(
+            "#{html_version}_fragment",
+            "<div>tweedle<section>beetle</section>bottle<span>puddle</span>paddle<div>battle</div>muddle</div>",
+          )
+
+          assert_equal "\ntweedle\nbeetle\nbottlepuddlepaddle\nbattle\nmuddle\n", html.to_text
+        end
+
+        it "remove extraneous whitespace" do
+          html = Loofah.send(
+            "#{html_version}_fragment",
+            "<div>tweedle\n\n\t\n\s\nbeetle</div>",
+          )
+
+          assert_equal "\ntweedle\n\nbeetle\n", html.to_text
+        end
+
+        it "replaces <br> with newlines" do
+          html = Loofah.send(
+            "#{html_version}_fragment",
+            "hello<div>first line<br>second line</div>goodbye",
+          )
+
+          assert_equal("hello\nfirst line\nsecond line\ngoodbye", html.to_text)
+        end
+      end
+
+      context "with an `encoding` arg" do
+        it "sets the parent document's encoding to accordingly" do
+          html = Loofah.send(
+            "#{html_version}_fragment",
+            "<style>foo</style><div>bar</div>",
+            "US-ASCII",
+          )
+
+          assert_equal "US-ASCII", html.document.encoding
+        end
       end
     end
 
-    context "#text" do
-      it "includes header tags (like style)" do
-        html = "<style>foo</style><div>bar</div>"
-        expected = "foobar"
-        assert_equal(expected, Loofah.html4_fragment(html).text)
+    context "#{html_version} document" do
+      context "#text" do
+        it "not include head tags (like style)" do
+          html = Loofah.send(
+            "#{html_version}_document",
+            "<style>foo</style><div>bar</div>",
+          )
 
-        # assumption check is that Nokogiri does the same
-        assert_equal(expected, Nokogiri::HTML4::DocumentFragment.parse(html).text)
-        assert_equal(expected, Nokogiri::HTML5::DocumentFragment.parse(html).text)
+          assert_equal "bar", html.text
+        end
       end
 
-      it "does not include cdata tags (like comments)" do
-        html = "<div>bar<!-- comment1 --></div><!-- comment2 -->"
-        expected = "bar"
-        assert_equal(expected, Loofah.html4_fragment(html).text)
+      context "#to_text" do
+        it "add newlines before and after html4 block elements" do
+          html = Loofah.send(
+            "#{html_version}_document",
+            "<div>tweedle<h1>beetle</h1>bottle<span>puddle</span>paddle<div>battle</div>muddle</div>",
+          )
 
-        # assumption check is that Nokogiri does the same
-        assert_equal(expected, Nokogiri::HTML4::DocumentFragment.parse(html).text)
-        assert_equal(expected, Nokogiri::HTML5::DocumentFragment.parse(html).text)
-      end
-    end
+          assert_equal "\ntweedle\nbeetle\nbottlepuddlepaddle\nbattle\nmuddle\n", html.to_text
+        end
 
-    context "#to_text" do
-      it "add newlines before and after html4 block elements" do
-        html = Loofah.html4_fragment "<div>tweedle<h1>beetle</h1>bottle<span>puddle</span>paddle<div>battle</div>muddle</div>"
-        assert_equal "\ntweedle\nbeetle\nbottlepuddlepaddle\nbattle\nmuddle\n", html.to_text
-      end
+        it "add newlines before and after html5 block elements" do
+          html = Loofah.send(
+            "#{html_version}_document",
+            "<div>tweedle<section>beetle</section>bottle<span>puddle</span>paddle<div>battle</div>muddle</div>",
+          )
 
-      it "add newlines before and after html5 block elements" do
-        html = Loofah.html4_fragment "<div>tweedle<section>beetle</section>bottle<span>puddle</span>paddle<div>battle</div>muddle</div>"
-        assert_equal "\ntweedle\nbeetle\nbottlepuddlepaddle\nbattle\nmuddle\n", html.to_text
-      end
+          assert_equal "\ntweedle\nbeetle\nbottlepuddlepaddle\nbattle\nmuddle\n", html.to_text
+        end
 
-      it "remove extraneous whitespace" do
-        html = Loofah.html4_fragment "<div>tweedle\n\n\t\n\s\nbeetle</div>"
-        assert_equal "\ntweedle\n\nbeetle\n", html.to_text
-      end
+        it "remove extraneous whitespace" do
+          html = Loofah.send(
+            "#{html_version}_document",
+            "<div>tweedle\n\n\t\n\s\nbeetle</div>",
+          )
+          assert_equal "\ntweedle\n\nbeetle\n", html.to_text
+        end
 
-      it "replaces <br> with newlines" do
-        html = Loofah.html4_fragment("hello<div>first line<br>second line</div>goodbye")
-        assert_equal("hello\nfirst line\nsecond line\ngoodbye", html.to_text)
-      end
-    end
+        it "replaces <br> with newlines" do
+          html = Loofah.send(
+            "#{html_version}_document",
+            "<body>hello<div>first line<br>second line</div>goodbye</body>",
+          )
 
-    context "with an `encoding` arg" do
-      it "sets the parent document's encoding to accordingly" do
-        html = Loofah.html4_fragment "<style>foo</style><div>bar</div>", "US-ASCII"
-        assert_equal "US-ASCII", html.document.encoding
-      end
-    end
-  end
-
-  context "html document" do
-    context "#text" do
-      it "not include head tags (like style)" do
-        html = Loofah.html4_document "<style>foo</style><div>bar</div>"
-        assert_equal "bar", html.text
-      end
-    end
-
-    context "#to_text" do
-      it "add newlines before and after html4 block elements" do
-        html = Loofah.html4_document "<div>tweedle<h1>beetle</h1>bottle<span>puddle</span>paddle<div>battle</div>muddle</div>"
-        assert_equal "\ntweedle\nbeetle\nbottlepuddlepaddle\nbattle\nmuddle\n", html.to_text
-      end
-
-      it "add newlines before and after html5 block elements" do
-        html = Loofah.html4_document "<div>tweedle<section>beetle</section>bottle<span>puddle</span>paddle<div>battle</div>muddle</div>"
-        assert_equal "\ntweedle\nbeetle\nbottlepuddlepaddle\nbattle\nmuddle\n", html.to_text
-      end
-
-      it "remove extraneous whitespace" do
-        html = Loofah.html4_document "<div>tweedle\n\n\t\n\s\nbeetle</div>"
-        assert_equal "\ntweedle\n\nbeetle\n", html.to_text
-      end
-
-      it "replaces <br> with newlines" do
-        html = Loofah.html4_document("<body>hello<div>first line<br>second line</div>goodbye</body>")
-        assert_equal("hello\nfirst line\nsecond line\ngoodbye", html.to_text)
+          assert_equal("hello\nfirst line\nsecond line\ngoodbye", html.to_text)
+        end
       end
     end
   end

--- a/test/integration/test_html.rb
+++ b/test/integration/test_html.rb
@@ -6,7 +6,7 @@ class IntegrationTestHtml < Loofah::TestCase
       it "includes header tags (like style)" do
         html = "<style>foo</style><div>bar</div>"
         expected = "<style>foo</style><div>bar</div>"
-        assert_equal(expected, Loofah.fragment(html).to_s)
+        assert_equal(expected, Loofah.html4_fragment(html).to_s)
 
         # assumption check is that Nokogiri does the same
         assert_equal(expected, Nokogiri::HTML4::DocumentFragment.parse(html).to_s)
@@ -18,7 +18,7 @@ class IntegrationTestHtml < Loofah::TestCase
       it "includes header tags (like style)" do
         html = "<style>foo</style><div>bar</div>"
         expected = "foobar"
-        assert_equal(expected, Loofah.fragment(html).text)
+        assert_equal(expected, Loofah.html4_fragment(html).text)
 
         # assumption check is that Nokogiri does the same
         assert_equal(expected, Nokogiri::HTML4::DocumentFragment.parse(html).text)
@@ -28,7 +28,7 @@ class IntegrationTestHtml < Loofah::TestCase
       it "does not include cdata tags (like comments)" do
         html = "<div>bar<!-- comment1 --></div><!-- comment2 -->"
         expected = "bar"
-        assert_equal(expected, Loofah.fragment(html).text)
+        assert_equal(expected, Loofah.html4_fragment(html).text)
 
         # assumption check is that Nokogiri does the same
         assert_equal(expected, Nokogiri::HTML4::DocumentFragment.parse(html).text)
@@ -38,29 +38,29 @@ class IntegrationTestHtml < Loofah::TestCase
 
     context "#to_text" do
       it "add newlines before and after html4 block elements" do
-        html = Loofah.fragment "<div>tweedle<h1>beetle</h1>bottle<span>puddle</span>paddle<div>battle</div>muddle</div>"
+        html = Loofah.html4_fragment "<div>tweedle<h1>beetle</h1>bottle<span>puddle</span>paddle<div>battle</div>muddle</div>"
         assert_equal "\ntweedle\nbeetle\nbottlepuddlepaddle\nbattle\nmuddle\n", html.to_text
       end
 
       it "add newlines before and after html5 block elements" do
-        html = Loofah.fragment "<div>tweedle<section>beetle</section>bottle<span>puddle</span>paddle<div>battle</div>muddle</div>"
+        html = Loofah.html4_fragment "<div>tweedle<section>beetle</section>bottle<span>puddle</span>paddle<div>battle</div>muddle</div>"
         assert_equal "\ntweedle\nbeetle\nbottlepuddlepaddle\nbattle\nmuddle\n", html.to_text
       end
 
       it "remove extraneous whitespace" do
-        html = Loofah.fragment "<div>tweedle\n\n\t\n\s\nbeetle</div>"
+        html = Loofah.html4_fragment "<div>tweedle\n\n\t\n\s\nbeetle</div>"
         assert_equal "\ntweedle\n\nbeetle\n", html.to_text
       end
 
       it "replaces <br> with newlines" do
-        html = Loofah.fragment("hello<div>first line<br>second line</div>goodbye")
+        html = Loofah.html4_fragment("hello<div>first line<br>second line</div>goodbye")
         assert_equal("hello\nfirst line\nsecond line\ngoodbye", html.to_text)
       end
     end
 
     context "with an `encoding` arg" do
       it "sets the parent document's encoding to accordingly" do
-        html = Loofah.fragment "<style>foo</style><div>bar</div>", "US-ASCII"
+        html = Loofah.html4_fragment "<style>foo</style><div>bar</div>", "US-ASCII"
         assert_equal "US-ASCII", html.document.encoding
       end
     end
@@ -69,29 +69,29 @@ class IntegrationTestHtml < Loofah::TestCase
   context "html document" do
     context "#text" do
       it "not include head tags (like style)" do
-        html = Loofah.document "<style>foo</style><div>bar</div>"
+        html = Loofah.html4_document "<style>foo</style><div>bar</div>"
         assert_equal "bar", html.text
       end
     end
 
     context "#to_text" do
       it "add newlines before and after html4 block elements" do
-        html = Loofah.document "<div>tweedle<h1>beetle</h1>bottle<span>puddle</span>paddle<div>battle</div>muddle</div>"
+        html = Loofah.html4_document "<div>tweedle<h1>beetle</h1>bottle<span>puddle</span>paddle<div>battle</div>muddle</div>"
         assert_equal "\ntweedle\nbeetle\nbottlepuddlepaddle\nbattle\nmuddle\n", html.to_text
       end
 
       it "add newlines before and after html5 block elements" do
-        html = Loofah.document "<div>tweedle<section>beetle</section>bottle<span>puddle</span>paddle<div>battle</div>muddle</div>"
+        html = Loofah.html4_document "<div>tweedle<section>beetle</section>bottle<span>puddle</span>paddle<div>battle</div>muddle</div>"
         assert_equal "\ntweedle\nbeetle\nbottlepuddlepaddle\nbattle\nmuddle\n", html.to_text
       end
 
       it "remove extraneous whitespace" do
-        html = Loofah.document "<div>tweedle\n\n\t\n\s\nbeetle</div>"
+        html = Loofah.html4_document "<div>tweedle\n\n\t\n\s\nbeetle</div>"
         assert_equal "\ntweedle\n\nbeetle\n", html.to_text
       end
 
       it "replaces <br> with newlines" do
-        html = Loofah.document("<body>hello<div>first line<br>second line</div>goodbye</body>")
+        html = Loofah.html4_document("<body>hello<div>first line<br>second line</div>goodbye</body>")
         assert_equal("hello\nfirst line\nsecond line\ngoodbye", html.to_text)
       end
     end

--- a/test/integration/test_scrubbers.rb
+++ b/test/integration/test_scrubbers.rb
@@ -36,7 +36,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
     context "#scrub!" do
       context ":escape" do
         it "escape bad tags" do
-          doc = Loofah::HTML::Document.parse "<html><body>#{INVALID_FRAGMENT}</body></html>"
+          doc = Loofah::HTML4::Document.parse "<html><body>#{INVALID_FRAGMENT}</body></html>"
           result = doc.scrub! :escape
 
           assert_equal INVALID_ESCAPED, doc.xpath("/html/body").inner_html
@@ -46,7 +46,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
       context ":prune" do
         it "prune bad tags" do
-          doc = Loofah::HTML::Document.parse "<html><body>#{INVALID_FRAGMENT}</body></html>"
+          doc = Loofah::HTML4::Document.parse "<html><body>#{INVALID_FRAGMENT}</body></html>"
           result = doc.scrub! :prune
 
           assert_equal INVALID_PRUNED, doc.xpath("/html/body").inner_html
@@ -56,7 +56,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
       context ":strip" do
         it "strip bad tags" do
-          doc = Loofah::HTML::Document.parse "<html><body>#{INVALID_FRAGMENT}</body></html>"
+          doc = Loofah::HTML4::Document.parse "<html><body>#{INVALID_FRAGMENT}</body></html>"
           result = doc.scrub! :strip
 
           assert_equal INVALID_STRIPPED, doc.xpath("/html/body").inner_html
@@ -66,7 +66,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
       context ":whitewash" do
         it "whitewash the markup" do
-          doc = Loofah::HTML::Document.parse "<html><body>#{WHITEWASH_FRAGMENT}</body></html>"
+          doc = Loofah::HTML4::Document.parse "<html><body>#{WHITEWASH_FRAGMENT}</body></html>"
           result = doc.scrub! :whitewash
 
           ww_result = Nokogiri.uses_libxml?("<2.9.11") ? WHITEWASH_RESULT : WHITEWASH_RESULT_LIBXML2911
@@ -77,7 +77,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
       context ":nofollow" do
         it "add a 'nofollow' attribute to hyperlinks" do
-          doc = Loofah::HTML::Document.parse "<html><body>#{NOFOLLOW_FRAGMENT}</body></html>"
+          doc = Loofah::HTML4::Document.parse "<html><body>#{NOFOLLOW_FRAGMENT}</body></html>"
           result = doc.scrub! :nofollow
 
           assert_equal NOFOLLOW_RESULT, doc.xpath("/html/body").inner_html
@@ -87,7 +87,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
       context ":unprintable" do
         it "removes unprintable unicode characters" do
-          doc = Loofah::HTML::Document.parse "<html><body>#{UNPRINTABLE_FRAGMENT}</body></html>"
+          doc = Loofah::HTML4::Document.parse "<html><body>#{UNPRINTABLE_FRAGMENT}</body></html>"
           result = doc.scrub! :unprintable
 
           assert_equal UNPRINTABLE_RESULT, doc.xpath("/html/body").inner_html
@@ -110,7 +110,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
     context "#text" do
       it "leave behind only inner text with html entities still escaped" do
-        doc = Loofah::HTML::Document.parse "<html><body>#{ENTITY_HACK_ATTACK}</body></html>"
+        doc = Loofah::HTML4::Document.parse "<html><body>#{ENTITY_HACK_ATTACK}</body></html>"
         result = doc.text
 
         assert_equal ENTITY_HACK_ATTACK_TEXT_SCRUB, result
@@ -118,7 +118,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
       context "with encode_special_chars => false" do
         it "leave behind only inner text with html entities unescaped" do
-          doc = Loofah::HTML::Document.parse "<html><body>#{ENTITY_HACK_ATTACK}</body></html>"
+          doc = Loofah::HTML4::Document.parse "<html><body>#{ENTITY_HACK_ATTACK}</body></html>"
           result = doc.text(:encode_special_chars => false)
 
           assert_equal ENTITY_HACK_ATTACK_TEXT_SCRUB_UNESC, result
@@ -127,7 +127,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
       context "with encode_special_chars => true" do
         it "leave behind only inner text with html entities still escaped" do
-          doc = Loofah::HTML::Document.parse "<html><body>#{ENTITY_HACK_ATTACK}</body></html>"
+          doc = Loofah::HTML4::Document.parse "<html><body>#{ENTITY_HACK_ATTACK}</body></html>"
           result = doc.text(:encode_special_chars => true)
 
           assert_equal ENTITY_HACK_ATTACK_TEXT_SCRUB, result
@@ -217,7 +217,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
     context "#scrub!" do
       context ":escape" do
         it "escape bad tags" do
-          doc = Loofah::HTML::DocumentFragment.parse "<div>#{INVALID_FRAGMENT}</div>"
+          doc = Loofah::HTML4::DocumentFragment.parse "<div>#{INVALID_FRAGMENT}</div>"
           result = doc.scrub! :escape
 
           assert_equal INVALID_ESCAPED, doc.xpath("./div").inner_html
@@ -227,7 +227,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
       context ":prune" do
         it "prune bad tags" do
-          doc = Loofah::HTML::DocumentFragment.parse "<div>#{INVALID_FRAGMENT}</div>"
+          doc = Loofah::HTML4::DocumentFragment.parse "<div>#{INVALID_FRAGMENT}</div>"
           result = doc.scrub! :prune
 
           assert_equal INVALID_PRUNED, doc.xpath("./div").inner_html
@@ -237,7 +237,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
       context ":strip" do
         it "strip bad tags" do
-          doc = Loofah::HTML::DocumentFragment.parse "<div>#{INVALID_FRAGMENT}</div>"
+          doc = Loofah::HTML4::DocumentFragment.parse "<div>#{INVALID_FRAGMENT}</div>"
           result = doc.scrub! :strip
 
           assert_equal INVALID_STRIPPED, doc.xpath("./div").inner_html
@@ -247,7 +247,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
       context ":whitewash" do
         it "whitewash the markup" do
-          doc = Loofah::HTML::DocumentFragment.parse "<div>#{WHITEWASH_FRAGMENT}</div>"
+          doc = Loofah::HTML4::DocumentFragment.parse "<div>#{WHITEWASH_FRAGMENT}</div>"
           result = doc.scrub! :whitewash
 
           ww_result = Nokogiri.uses_libxml?("<2.9.11") ? WHITEWASH_RESULT : WHITEWASH_RESULT_LIBXML2911
@@ -259,7 +259,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
       context ":nofollow" do
         context "for a hyperlink that does not have a rel attribute" do
           it "add a 'nofollow' attribute to hyperlinks" do
-            doc = Loofah::HTML::DocumentFragment.parse "<div>#{NOFOLLOW_FRAGMENT}</div>"
+            doc = Loofah::HTML4::DocumentFragment.parse "<div>#{NOFOLLOW_FRAGMENT}</div>"
             result = doc.scrub! :nofollow
 
             assert_equal NOFOLLOW_RESULT, doc.xpath("./div").inner_html
@@ -269,7 +269,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
         context "for a hyperlink that does have a rel attribute" do
           it "appends nofollow to rel attribute" do
-            doc = Loofah::HTML::DocumentFragment.parse "<div>#{NOFOLLOW_WITH_REL_FRAGMENT}</div>"
+            doc = Loofah::HTML4::DocumentFragment.parse "<div>#{NOFOLLOW_WITH_REL_FRAGMENT}</div>"
             result = doc.scrub! :nofollow
 
             assert_equal NOFOLLOW_WITH_REL_RESULT, doc.xpath("./div").inner_html
@@ -281,7 +281,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
       context ":noopener" do
         context "for a hyperlink without a 'rel' attribute" do
           it "add a 'noopener' attribute to hyperlinks" do
-            doc = Loofah::HTML::DocumentFragment.parse "<div>#{NOOPENER_FRAGMENT}</div>"
+            doc = Loofah::HTML4::DocumentFragment.parse "<div>#{NOOPENER_FRAGMENT}</div>"
             result = doc.scrub! :noopener
 
             assert_equal NOOPENER_RESULT, doc.xpath("./div").inner_html
@@ -291,7 +291,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
         context "for a hyperlink that does have a rel attribute" do
           it "appends 'noopener' to 'rel' attribute" do
-            doc = Loofah::HTML::DocumentFragment.parse "<div>#{NOOPENER_WITH_REL_FRAGMENT}</div>"
+            doc = Loofah::HTML4::DocumentFragment.parse "<div>#{NOOPENER_WITH_REL_FRAGMENT}</div>"
             result = doc.scrub! :noopener
 
             assert_equal NOOPENER_WITH_REL_RESULT, doc.xpath("./div").inner_html
@@ -302,7 +302,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
       context ":unprintable" do
         it "removes unprintable unicode characters" do
-          doc = Loofah::HTML::DocumentFragment.parse "<div>#{UNPRINTABLE_FRAGMENT}</div>"
+          doc = Loofah::HTML4::DocumentFragment.parse "<div>#{UNPRINTABLE_FRAGMENT}</div>"
           result = doc.scrub! :unprintable
 
           assert_equal UNPRINTABLE_RESULT, doc.xpath("./div").inner_html
@@ -325,7 +325,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
     context "#text" do
       it "leave behind only inner text with html entities still escaped" do
-        doc = Loofah::HTML::DocumentFragment.parse "<div>#{ENTITY_HACK_ATTACK}</div>"
+        doc = Loofah::HTML4::DocumentFragment.parse "<div>#{ENTITY_HACK_ATTACK}</div>"
         result = doc.text
 
         assert_equal ENTITY_HACK_ATTACK_TEXT_SCRUB, result
@@ -333,7 +333,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
       context "with encode_special_chars => false" do
         it "leave behind only inner text with html entities unescaped" do
-          doc = Loofah::HTML::DocumentFragment.parse "<div>#{ENTITY_HACK_ATTACK}</div>"
+          doc = Loofah::HTML4::DocumentFragment.parse "<div>#{ENTITY_HACK_ATTACK}</div>"
           result = doc.text(:encode_special_chars => false)
 
           assert_equal ENTITY_HACK_ATTACK_TEXT_SCRUB_UNESC, result
@@ -342,7 +342,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
       context "with encode_special_chars => true" do
         it "leave behind only inner text with html entities still escaped" do
-          doc = Loofah::HTML::DocumentFragment.parse "<div>#{ENTITY_HACK_ATTACK}</div>"
+          doc = Loofah::HTML4::DocumentFragment.parse "<div>#{ENTITY_HACK_ATTACK}</div>"
           result = doc.text(:encode_special_chars => true)
 
           assert_equal ENTITY_HACK_ATTACK_TEXT_SCRUB, result

--- a/test/integration/test_scrubbers.rb
+++ b/test/integration/test_scrubbers.rb
@@ -100,8 +100,22 @@ class IntegrationTestScrubbers < Loofah::TestCase
       it "is a shortcut for parse-and-scrub" do
         mock_doc = MiniTest::Mock.new
         mock_doc.expect(:scrub!, "sanitized_string", [:method])
-        Loofah.stub(:document, mock_doc) do
+
+        Loofah::HTML4::Document.stub(:parse, mock_doc) do
           Loofah.scrub_document("string", :method)
+        end
+
+        mock_doc.verify
+      end
+    end
+
+    context "#scrub_html4_document" do
+      it "is a shortcut for parse-and-scrub" do
+        mock_doc = MiniTest::Mock.new
+        mock_doc.expect(:scrub!, "sanitized_string", [:method])
+
+        Loofah::HTML4::Document.stub(:parse, mock_doc) do
+          Loofah.scrub_html4_document("string", :method)
         end
 
         mock_doc.verify
@@ -137,7 +151,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
     context "#to_s" do
       it "generate HTML" do
-        doc = Loofah.scrub_document "<html><head><title>quux</title></head><body><div>foo</div></body></html>", :prune
+        doc = Loofah.scrub_html4_document "<html><head><title>quux</title></head><body><div>foo</div></body></html>", :prune
         refute_nil doc.xpath("/html").first
         refute_nil doc.xpath("/html/head").first
         refute_nil doc.xpath("/html/body").first
@@ -152,7 +166,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
     context "#serialize" do
       it "generate HTML" do
-        doc = Loofah.scrub_document "<html><head><title>quux</title></head><body><div>foo</div></body></html>", :prune
+        doc = Loofah.scrub_html4_document "<html><head><title>quux</title></head><body><div>foo</div></body></html>", :prune
         refute_nil doc.xpath("/html").first
         refute_nil doc.xpath("/html/head").first
         refute_nil doc.xpath("/html/body").first
@@ -168,7 +182,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
     context "Node" do
       context "#scrub!" do
         it "only scrub subtree" do
-          xml = Loofah.document <<-EOHTML
+          xml = Loofah.html4_document <<-EOHTML
            <html><body>
              <div class='scrub'>
                <script>I should be removed</script>
@@ -189,7 +203,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
     context "NodeSet" do
       context "#scrub!" do
         it "only scrub subtrees" do
-          xml = Loofah.document <<-EOHTML
+          xml = Loofah.html4_document <<-EOHTML
             <html><body>
               <div class='scrub'>
                 <script>I should be removed</script>
@@ -315,8 +329,22 @@ class IntegrationTestScrubbers < Loofah::TestCase
       it "is a shortcut for parse-and-scrub" do
         mock_doc = MiniTest::Mock.new
         mock_doc.expect(:scrub!, "sanitized_string", [:method])
-        Loofah.stub(:fragment, mock_doc) do
+
+        Loofah::HTML4::DocumentFragment.stub(:parse, mock_doc) do
           Loofah.scrub_fragment("string", :method)
+        end
+
+        mock_doc.verify
+      end
+    end
+
+    context "#scrub_html4_fragment" do
+      it "is a shortcut for parse-and-scrub" do
+        mock_doc = MiniTest::Mock.new
+        mock_doc.expect(:scrub!, "sanitized_string", [:method])
+
+        Loofah::HTML4::DocumentFragment.stub(:parse, mock_doc) do
+          Loofah.scrub_html4_fragment("string", :method)
         end
 
         mock_doc.verify
@@ -352,7 +380,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
     context "#to_s" do
       it "not remove entities" do
-        string = Loofah.scrub_fragment(ENTITY_FRAGMENT, :prune).to_s
+        string = Loofah.scrub_html4_fragment(ENTITY_FRAGMENT, :prune).to_s
         assert_match %r/this is &lt;/, string
       end
     end
@@ -360,7 +388,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
     context "Node" do
       context "#scrub!" do
         it "only scrub subtree" do
-          xml = Loofah.fragment <<-EOHTML
+          xml = Loofah.html4_fragment <<-EOHTML
             <div class='scrub'>
               <script>I should be removed</script>
             </div>
@@ -379,7 +407,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
     context "NodeSet" do
       context "#scrub!" do
         it "only scrub subtrees" do
-          xml = Loofah.fragment <<-EOHTML
+          xml = Loofah.html4_fragment <<-EOHTML
             <div class='scrub'>
               <script>I should be removed</script>
             </div>

--- a/test/unit/test_api.rb
+++ b/test/unit/test_api.rb
@@ -6,6 +6,20 @@ class UnitTestApi < Loofah::TestCase
   let(:xml) { "<root>#{xml_fragment}</root>" }
 
   describe Loofah::HTML do
+    it "is aliased to Loofah::HTML4" do
+      assert_equal(Loofah::HTML4, Loofah::HTML)
+      assert_equal(Loofah::HTML4::Document, Loofah::HTML::Document)
+      assert_equal(Loofah::HTML4::DocumentFragment, Loofah::HTML::DocumentFragment)
+    end
+
+    it "has an HTML4 name" do
+      assert_equal("Loofah::HTML4", Loofah::HTML.to_s)
+      assert_equal("Loofah::HTML4::Document", Loofah::HTML::Document.to_s)
+      assert_equal("Loofah::HTML4::DocumentFragment", Loofah::HTML::DocumentFragment.to_s)
+    end
+  end
+
+  describe Loofah::HTML4 do
     it "creates documents" do
       doc = Loofah.document(html)
       assert_html_documentish doc
@@ -17,12 +31,12 @@ class UnitTestApi < Loofah::TestCase
     end
 
     it "parses documents" do
-      doc = Loofah::HTML::Document.parse(html)
+      doc = Loofah::HTML4::Document.parse(html)
       assert_html_documentish doc
     end
 
     it "parses document fragment" do
-      doc = Loofah::HTML::DocumentFragment.parse(html)
+      doc = Loofah::HTML4::DocumentFragment.parse(html)
       assert_html_fragmentish doc
     end
 
@@ -62,12 +76,12 @@ class UnitTestApi < Loofah::TestCase
       node_set.scrub!(:strip)
     end
 
-    it "exposes serialize_root on Loofah::HTML::DocumentFragment" do
+    it "exposes serialize_root on Loofah::HTML4::DocumentFragment" do
       doc = Loofah.fragment(html)
       assert_equal html, doc.serialize_root.to_html
     end
 
-    it "exposes serialize_root on Loofah::HTML::Document" do
+    it "exposes serialize_root on Loofah::HTML4::Document" do
       doc = Loofah.document(html)
       assert_equal html, doc.serialize_root.children.to_html
     end
@@ -130,13 +144,13 @@ class UnitTestApi < Loofah::TestCase
 
   def assert_html_documentish(doc)
     assert_kind_of Nokogiri::HTML4::Document, doc
-    assert_kind_of Loofah::HTML::Document, doc
+    assert_kind_of Loofah::HTML4::Document, doc
     assert_equal html, doc.xpath("/html/body").inner_html
   end
 
   def assert_html_fragmentish(doc)
     assert_kind_of Nokogiri::HTML4::DocumentFragment, doc
-    assert_kind_of Loofah::HTML::DocumentFragment, doc
+    assert_kind_of Loofah::HTML4::DocumentFragment, doc
     assert_equal html, doc.inner_html
   end
 

--- a/test/unit/test_api.rb
+++ b/test/unit/test_api.rb
@@ -4,10 +4,21 @@ class UnitTestApi < Loofah::TestCase
   let(:html) { "<div>a</div>\n<div>b</div>" }
   let(:xml_fragment) { "<div>a</div>\n<div>b</div>" }
   let(:xml) { "<root>#{xml_fragment}</root>" }
+  let(:xml_scrubber) do
+    Loofah::Scrubber.new do |node|
+      # no-op
+    end
+  end
 
   describe Loofah do
     it "creates html4 documents" do
       doc = Loofah.document(html)
+      assert_kind_of(Loofah::HTML4::Document, doc)
+      assert_equal html, doc.xpath("/html/body").inner_html
+    end
+
+    it "scrubs html4 documents" do
+      doc = Loofah.scrub_document(html, :strip)
       assert_kind_of(Loofah::HTML4::Document, doc)
       assert_equal html, doc.xpath("/html/body").inner_html
     end
@@ -18,14 +29,32 @@ class UnitTestApi < Loofah::TestCase
       assert_equal html, doc.inner_html
     end
 
+    it "scrubs html4 fragments" do
+      doc = Loofah.scrub_fragment(html, :strip)
+      assert_kind_of(Loofah::HTML4::DocumentFragment, doc)
+      assert_equal html, doc.inner_html
+    end
+
     it "creates xml documents" do
       doc = Loofah.xml_document(xml)
       assert_kind_of(Loofah::XML::Document, doc)
       assert_equal xml, doc.root.to_xml
     end
 
+    it "scrubs xml documents" do
+      doc = Loofah.scrub_xml_document(xml, xml_scrubber)
+      assert_kind_of(Loofah::XML::Document, doc)
+      assert_equal xml, doc.root.to_xml
+    end
+
     it "creates xml fragments" do
       doc = Loofah.xml_fragment(xml_fragment)
+      assert_kind_of(Loofah::XML::DocumentFragment, doc)
+      assert_equal xml_fragment, doc.children.to_xml
+    end
+
+    it "scrubs xml fragments" do
+      doc = Loofah.scrub_xml_fragment(xml_fragment, :strip)
       assert_kind_of(Loofah::XML::DocumentFragment, doc)
       assert_equal xml_fragment, doc.children.to_xml
     end

--- a/test/unit/test_api.rb
+++ b/test/unit/test_api.rb
@@ -5,53 +5,62 @@ class UnitTestApi < Loofah::TestCase
   let(:xml_fragment) { "<div>a</div>\n<div>b</div>" }
   let(:xml) { "<root>#{xml_fragment}</root>" }
 
-  describe Loofah::HTML do
-    it "is aliased to Loofah::HTML4" do
-      assert_equal(Loofah::HTML4, Loofah::HTML)
-      assert_equal(Loofah::HTML4::Document, Loofah::HTML::Document)
-      assert_equal(Loofah::HTML4::DocumentFragment, Loofah::HTML::DocumentFragment)
+  describe Loofah do
+    it "creates html4 documents" do
+      doc = Loofah.document(html)
+      assert_kind_of(Loofah::HTML4::Document, doc)
+      assert_equal html, doc.xpath("/html/body").inner_html
     end
 
-    it "has an HTML4 name" do
-      assert_equal("Loofah::HTML4", Loofah::HTML.to_s)
-      assert_equal("Loofah::HTML4::Document", Loofah::HTML::Document.to_s)
-      assert_equal("Loofah::HTML4::DocumentFragment", Loofah::HTML::DocumentFragment.to_s)
+    it "creates html4 fragments" do
+      doc = Loofah.fragment(html)
+      assert_kind_of(Loofah::HTML4::DocumentFragment, doc)
+      assert_equal html, doc.inner_html
+    end
+
+    it "creates xml documents" do
+      doc = Loofah.xml_document(xml)
+      assert_kind_of(Loofah::XML::Document, doc)
+      assert_equal xml, doc.root.to_xml
+    end
+
+    it "creates xml fragments" do
+      doc = Loofah.xml_fragment(xml_fragment)
+      assert_kind_of(Loofah::XML::DocumentFragment, doc)
+      assert_equal xml_fragment, doc.children.to_xml
     end
   end
 
   describe Loofah::HTML4 do
-    it "creates documents" do
-      doc = Loofah.document(html)
-      assert_html_documentish doc
-    end
-
-    it "creates fragments" do
-      doc = Loofah.fragment(html)
-      assert_html_fragmentish doc
+    it "subclasses Nokogiri::HTML4" do
+      assert_includes(Loofah::HTML4::Document.ancestors, Nokogiri::HTML4::Document)
+      assert_includes(Loofah::HTML4::DocumentFragment.ancestors, Nokogiri::HTML4::DocumentFragment)
     end
 
     it "parses documents" do
       doc = Loofah::HTML4::Document.parse(html)
-      assert_html_documentish doc
+      assert_kind_of(Loofah::HTML4::Document, doc)
+      assert_equal html, doc.xpath("/html/body").inner_html
     end
 
     it "parses document fragment" do
       doc = Loofah::HTML4::DocumentFragment.parse(html)
-      assert_html_fragmentish doc
+      assert_kind_of(Loofah::HTML4::DocumentFragment, doc)
+      assert_equal html, doc.inner_html
     end
 
     it "scrubs documents" do
-      doc = Loofah.document(html).scrub!(:strip)
-      assert_html_documentish doc
+      doc = Loofah::HTML4::Document.parse(html).scrub!(:strip)
+      assert_equal html, doc.xpath("/html/body").inner_html
     end
 
     it "scrubs fragments" do
-      doc = Loofah.fragment(html).scrub!(:strip)
-      assert_html_fragmentish doc
+      doc = Loofah::HTML4::DocumentFragment.parse(html).scrub!(:strip)
+      assert_equal html, doc.inner_html
     end
 
     it "scrubs document nodes" do
-      doc = Loofah.document(html)
+      doc = Loofah::HTML4::Document.parse(html)
       assert(node = doc.at_css("div"))
       node.scrub!(:strip)
     end
@@ -88,36 +97,33 @@ class UnitTestApi < Loofah::TestCase
   end
 
   describe Loofah::XML do
-    it "creates documents" do
-      doc = Loofah.xml_document(xml)
-      assert_xml_documentish doc
-    end
-
-    it "creates fragments" do
-      doc = Loofah.xml_fragment(xml_fragment)
-      assert_xml_fragmentish doc
+    it "subclasses Nokogiri::XML" do
+      assert_includes(Loofah::XML::Document.ancestors, Nokogiri::XML::Document)
+      assert_includes(Loofah::XML::DocumentFragment.ancestors, Nokogiri::XML::DocumentFragment)
     end
 
     it "parses documents" do
       doc = Loofah::XML::Document.parse(xml)
-      assert_xml_documentish doc
+      assert_kind_of(Loofah::XML::Document, doc)
+      assert_equal xml, doc.root.to_xml
     end
 
     it "parses document fragments" do
       doc = Loofah::XML::DocumentFragment.parse(xml_fragment)
-      assert_xml_fragmentish doc
+      assert_kind_of(Loofah::XML::DocumentFragment, doc)
+      assert_equal xml_fragment, doc.children.to_xml
     end
 
     it "scrubs documents" do
       scrubber = Loofah::Scrubber.new { |node| }
       doc = Loofah.xml_document(xml).scrub!(scrubber)
-      assert_xml_documentish doc
+      assert_equal xml, doc.root.to_xml
     end
 
     it "scrubs fragments" do
       scrubber = Loofah::Scrubber.new { |node| }
       doc = Loofah.xml_fragment(xml_fragment).scrub!(scrubber)
-      assert_xml_fragmentish doc
+      assert_equal xml_fragment, doc.children.to_xml
     end
 
     it "scrubs document nodes" do
@@ -140,29 +146,17 @@ class UnitTestApi < Loofah::TestCase
     end
   end
 
-  private
+  describe Loofah::HTML do
+    it "is aliased to Loofah::HTML4" do
+      assert_equal(Loofah::HTML4, Loofah::HTML)
+      assert_equal(Loofah::HTML4::Document, Loofah::HTML::Document)
+      assert_equal(Loofah::HTML4::DocumentFragment, Loofah::HTML::DocumentFragment)
+    end
 
-  def assert_html_documentish(doc)
-    assert_kind_of Nokogiri::HTML4::Document, doc
-    assert_kind_of Loofah::HTML4::Document, doc
-    assert_equal html, doc.xpath("/html/body").inner_html
-  end
-
-  def assert_html_fragmentish(doc)
-    assert_kind_of Nokogiri::HTML4::DocumentFragment, doc
-    assert_kind_of Loofah::HTML4::DocumentFragment, doc
-    assert_equal html, doc.inner_html
-  end
-
-  def assert_xml_documentish(doc)
-    assert_kind_of Nokogiri::XML::Document, doc
-    assert_kind_of Loofah::XML::Document, doc
-    assert_equal xml, doc.root.to_xml
-  end
-
-  def assert_xml_fragmentish(doc)
-    assert_kind_of Nokogiri::XML::DocumentFragment, doc
-    assert_kind_of Loofah::XML::DocumentFragment, doc
-    assert_equal xml_fragment, doc.children.to_xml
+    it "has an HTML4 name" do
+      assert_equal("Loofah::HTML4", Loofah::HTML.to_s)
+      assert_equal("Loofah::HTML4::Document", Loofah::HTML::Document.to_s)
+      assert_equal("Loofah::HTML4::DocumentFragment", Loofah::HTML::DocumentFragment.to_s)
+    end
   end
 end

--- a/test/unit/test_api.rb
+++ b/test/unit/test_api.rb
@@ -17,8 +17,20 @@ class UnitTestApi < Loofah::TestCase
       assert_equal html, doc.xpath("/html/body").inner_html
     end
 
+    it "creates html4 documents" do
+      doc = Loofah.html4_document(html)
+      assert_kind_of(Loofah::HTML4::Document, doc)
+      assert_equal html, doc.xpath("/html/body").inner_html
+    end
+
     it "scrubs html4 documents" do
       doc = Loofah.scrub_document(html, :strip)
+      assert_kind_of(Loofah::HTML4::Document, doc)
+      assert_equal html, doc.xpath("/html/body").inner_html
+    end
+
+    it "scrubs html4 documents" do
+      doc = Loofah.scrub_html4_document(html, :strip)
       assert_kind_of(Loofah::HTML4::Document, doc)
       assert_equal html, doc.xpath("/html/body").inner_html
     end
@@ -29,8 +41,20 @@ class UnitTestApi < Loofah::TestCase
       assert_equal html, doc.inner_html
     end
 
+    it "creates html4 fragments" do
+      doc = Loofah.html4_fragment(html)
+      assert_kind_of(Loofah::HTML4::DocumentFragment, doc)
+      assert_equal html, doc.inner_html
+    end
+
     it "scrubs html4 fragments" do
       doc = Loofah.scrub_fragment(html, :strip)
+      assert_kind_of(Loofah::HTML4::DocumentFragment, doc)
+      assert_equal html, doc.inner_html
+    end
+
+    it "scrubs html4 fragments" do
+      doc = Loofah.scrub_html4_fragment(html, :strip)
       assert_kind_of(Loofah::HTML4::DocumentFragment, doc)
       assert_equal html, doc.inner_html
     end
@@ -88,39 +112,49 @@ class UnitTestApi < Loofah::TestCase
       assert_equal html, doc.inner_html
     end
 
-    it "scrubs document nodes" do
+    it "adds instance methods to documents" do
+      doc = Loofah::HTML4::Document.parse(html)
+      doc.scrub!(:strip)
+    end
+
+    it "adds instance methods to document nodes" do
       doc = Loofah::HTML4::Document.parse(html)
       assert(node = doc.at_css("div"))
       node.scrub!(:strip)
     end
 
-    it "scrubs fragment nodes" do
-      doc = Loofah.fragment(html)
+    it "adds instance methods to fragments" do
+      doc = Loofah::HTML4::DocumentFragment.parse(html)
+      doc.scrub!(:strip)
+    end
+
+    it "adds instance methods to fragment nodes" do
+      doc = Loofah::HTML4::DocumentFragment.parse(html)
       assert(node = doc.at_css("div"))
       node.scrub!(:strip)
     end
 
-    it "scrubs document nodesets" do
-      doc = Loofah.document(html)
+    it "adds instance methods to document nodesets" do
+      doc = Loofah.html4_document(html)
       assert(node_set = doc.css("div"))
       assert_instance_of Nokogiri::XML::NodeSet, node_set
       node_set.scrub!(:strip)
     end
 
-    it "scrubs fragment nodesets" do
-      doc = Loofah.fragment(html)
+    it "adds instance methods to fragment nodesets" do
+      doc = Loofah.html4_fragment(html)
       assert(node_set = doc.css("div"))
       assert_instance_of Nokogiri::XML::NodeSet, node_set
       node_set.scrub!(:strip)
     end
 
     it "exposes serialize_root on Loofah::HTML4::DocumentFragment" do
-      doc = Loofah.fragment(html)
+      doc = Loofah.html4_fragment(html)
       assert_equal html, doc.serialize_root.to_html
     end
 
     it "exposes serialize_root on Loofah::HTML4::Document" do
-      doc = Loofah.document(html)
+      doc = Loofah.html4_document(html)
       assert_equal html, doc.serialize_root.children.to_html
     end
   end
@@ -155,20 +189,38 @@ class UnitTestApi < Loofah::TestCase
       assert_equal xml_fragment, doc.children.to_xml
     end
 
-    it "scrubs document nodes" do
+    it "adds instance methods to documents" do
+      doc = Loofah.xml_document(xml)
+      scrubber = Loofah::Scrubber.new { |node| }
+      doc.scrub!(scrubber)
+    end
+
+    it "adds instance methods to document nodes" do
       doc = Loofah.xml_document(xml)
       assert(node = doc.at_css("div"))
       node.scrub!(:strip)
     end
 
-    it "scrubs fragment nodes" do
+    it "adds instance methods to fragments" do
+      doc = Loofah.xml_fragment(xml)
+      doc.scrub!(:strip)
+    end
+
+    it "adds instance methods to fragment nodes" do
       doc = Loofah.xml_fragment(xml)
       assert(node = doc.at_css("div"))
       node.scrub!(:strip)
     end
 
-    it "scrubs document nodesets" do
+    it "adds instance methods to document nodesets" do
       doc = Loofah.xml_document(xml)
+      assert(node_set = doc.css("div"))
+      assert_instance_of Nokogiri::XML::NodeSet, node_set
+      node_set.scrub!(:strip)
+    end
+
+    it "adds instance methods to document nodesets" do
+      doc = Loofah.xml_fragment(xml)
       assert(node_set = doc.css("div"))
       assert_instance_of Nokogiri::XML::NodeSet, node_set
       node_set.scrub!(:strip)

--- a/test/unit/test_api.rb
+++ b/test/unit/test_api.rb
@@ -11,76 +11,108 @@ class UnitTestApi < Loofah::TestCase
   end
 
   describe Loofah do
-    it "creates html4 documents" do
-      doc = Loofah.document(html)
-      assert_kind_of(Loofah::HTML4::Document, doc)
-      assert_equal html, doc.xpath("/html/body").inner_html
+    describe "generic class methods" do
+      it "creates html4 documents" do
+        doc = Loofah.document(html)
+        assert_kind_of(Loofah::HTML4::Document, doc)
+        assert_equal html, doc.xpath("/html/body").inner_html
+      end
+
+      it "scrubs html4 documents" do
+        doc = Loofah.scrub_document(html, :strip)
+        assert_kind_of(Loofah::HTML4::Document, doc)
+        assert_equal html, doc.xpath("/html/body").inner_html
+      end
+
+      it "creates html4 fragments" do
+        doc = Loofah.fragment(html)
+        assert_kind_of(Loofah::HTML4::DocumentFragment, doc)
+        assert_equal html, doc.inner_html
+      end
+
+      it "scrubs html4 fragments" do
+        doc = Loofah.scrub_fragment(html, :strip)
+        assert_kind_of(Loofah::HTML4::DocumentFragment, doc)
+        assert_equal html, doc.inner_html
+      end
     end
 
-    it "creates html4 documents" do
-      doc = Loofah.html4_document(html)
-      assert_kind_of(Loofah::HTML4::Document, doc)
-      assert_equal html, doc.xpath("/html/body").inner_html
+    describe "html4 methods" do
+      it "creates html4 documents" do
+        doc = Loofah.html4_document(html)
+        assert_kind_of(Loofah::HTML4::Document, doc)
+        assert_equal html, doc.xpath("/html/body").inner_html
+      end
+
+      it "scrubs html4 documents" do
+        doc = Loofah.scrub_html4_document(html, :strip)
+        assert_kind_of(Loofah::HTML4::Document, doc)
+        assert_equal html, doc.xpath("/html/body").inner_html
+      end
+
+      it "creates html4 fragments" do
+        doc = Loofah.html4_fragment(html)
+        assert_kind_of(Loofah::HTML4::DocumentFragment, doc)
+        assert_equal html, doc.inner_html
+      end
+
+      it "scrubs html4 fragments" do
+        doc = Loofah.scrub_html4_fragment(html, :strip)
+        assert_kind_of(Loofah::HTML4::DocumentFragment, doc)
+        assert_equal html, doc.inner_html
+      end
     end
 
-    it "scrubs html4 documents" do
-      doc = Loofah.scrub_document(html, :strip)
-      assert_kind_of(Loofah::HTML4::Document, doc)
-      assert_equal html, doc.xpath("/html/body").inner_html
+    describe "html5 methods" do
+      it "creates html5 documents" do
+        doc = Loofah.html5_document(html)
+        assert_kind_of(Loofah::HTML5::Document, doc)
+        assert_equal html, doc.xpath("/html/body").inner_html
+      end
+
+      it "scrubs html5 documents" do
+        doc = Loofah.scrub_html5_document(html, :strip)
+        assert_kind_of(Loofah::HTML5::Document, doc)
+        assert_equal html, doc.xpath("/html/body").inner_html
+      end
+
+      it "creates html5 fragments" do
+        doc = Loofah.html5_fragment(html)
+        assert_kind_of(Loofah::HTML5::DocumentFragment, doc)
+        assert_equal html, doc.inner_html
+      end
+
+      it "scrubs html5 fragments" do
+        doc = Loofah.scrub_html5_fragment(html, :strip)
+        assert_kind_of(Loofah::HTML5::DocumentFragment, doc)
+        assert_equal html, doc.inner_html
+      end
     end
 
-    it "scrubs html4 documents" do
-      doc = Loofah.scrub_html4_document(html, :strip)
-      assert_kind_of(Loofah::HTML4::Document, doc)
-      assert_equal html, doc.xpath("/html/body").inner_html
-    end
+    describe "xml methods" do
+      it "creates xml documents" do
+        doc = Loofah.xml_document(xml)
+        assert_kind_of(Loofah::XML::Document, doc)
+        assert_equal xml, doc.root.to_xml
+      end
 
-    it "creates html4 fragments" do
-      doc = Loofah.fragment(html)
-      assert_kind_of(Loofah::HTML4::DocumentFragment, doc)
-      assert_equal html, doc.inner_html
-    end
+      it "scrubs xml documents" do
+        doc = Loofah.scrub_xml_document(xml, xml_scrubber)
+        assert_kind_of(Loofah::XML::Document, doc)
+        assert_equal xml, doc.root.to_xml
+      end
 
-    it "creates html4 fragments" do
-      doc = Loofah.html4_fragment(html)
-      assert_kind_of(Loofah::HTML4::DocumentFragment, doc)
-      assert_equal html, doc.inner_html
-    end
+      it "creates xml fragments" do
+        doc = Loofah.xml_fragment(xml_fragment)
+        assert_kind_of(Loofah::XML::DocumentFragment, doc)
+        assert_equal xml_fragment, doc.children.to_xml
+      end
 
-    it "scrubs html4 fragments" do
-      doc = Loofah.scrub_fragment(html, :strip)
-      assert_kind_of(Loofah::HTML4::DocumentFragment, doc)
-      assert_equal html, doc.inner_html
-    end
-
-    it "scrubs html4 fragments" do
-      doc = Loofah.scrub_html4_fragment(html, :strip)
-      assert_kind_of(Loofah::HTML4::DocumentFragment, doc)
-      assert_equal html, doc.inner_html
-    end
-
-    it "creates xml documents" do
-      doc = Loofah.xml_document(xml)
-      assert_kind_of(Loofah::XML::Document, doc)
-      assert_equal xml, doc.root.to_xml
-    end
-
-    it "scrubs xml documents" do
-      doc = Loofah.scrub_xml_document(xml, xml_scrubber)
-      assert_kind_of(Loofah::XML::Document, doc)
-      assert_equal xml, doc.root.to_xml
-    end
-
-    it "creates xml fragments" do
-      doc = Loofah.xml_fragment(xml_fragment)
-      assert_kind_of(Loofah::XML::DocumentFragment, doc)
-      assert_equal xml_fragment, doc.children.to_xml
-    end
-
-    it "scrubs xml fragments" do
-      doc = Loofah.scrub_xml_fragment(xml_fragment, :strip)
-      assert_kind_of(Loofah::XML::DocumentFragment, doc)
-      assert_equal xml_fragment, doc.children.to_xml
+      it "scrubs xml fragments" do
+        doc = Loofah.scrub_xml_fragment(xml_fragment, :strip)
+        assert_kind_of(Loofah::XML::DocumentFragment, doc)
+        assert_equal xml_fragment, doc.children.to_xml
+      end
     end
   end
 

--- a/test/unit/test_api.rb
+++ b/test/unit/test_api.rb
@@ -1,125 +1,125 @@
 require "helper"
 
 class UnitTestApi < Loofah::TestCase
-  HTML = "<div>a</div>\n<div>b</div>"
-  XML_FRAGMENT = "<div>a</div>\n<div>b</div>"
-  XML = "<root>#{XML_FRAGMENT}</root>"
+  let(:html) { "<div>a</div>\n<div>b</div>" }
+  let(:xml_fragment) { "<div>a</div>\n<div>b</div>" }
+  let(:xml) { "<root>#{xml_fragment}</root>" }
 
-  describe "HTML" do
+  describe Loofah::HTML do
     it "creates documents" do
-      doc = Loofah.document(HTML)
+      doc = Loofah.document(html)
       assert_html_documentish doc
     end
 
     it "creates fragments" do
-      doc = Loofah.fragment(HTML)
+      doc = Loofah.fragment(html)
       assert_html_fragmentish doc
     end
 
     it "parses documents" do
-      doc = Loofah::HTML::Document.parse(HTML)
+      doc = Loofah::HTML::Document.parse(html)
       assert_html_documentish doc
     end
 
     it "parses document fragment" do
-      doc = Loofah::HTML::DocumentFragment.parse(HTML)
+      doc = Loofah::HTML::DocumentFragment.parse(html)
       assert_html_fragmentish doc
     end
 
     it "scrubs documents" do
-      doc = Loofah.document(HTML).scrub!(:strip)
+      doc = Loofah.document(html).scrub!(:strip)
       assert_html_documentish doc
     end
 
     it "scrubs fragments" do
-      doc = Loofah.fragment(HTML).scrub!(:strip)
+      doc = Loofah.fragment(html).scrub!(:strip)
       assert_html_fragmentish doc
     end
 
     it "scrubs document nodes" do
-      doc = Loofah.document(HTML)
+      doc = Loofah.document(html)
       assert(node = doc.at_css("div"))
       node.scrub!(:strip)
     end
 
     it "scrubs fragment nodes" do
-      doc = Loofah.fragment(HTML)
+      doc = Loofah.fragment(html)
       assert(node = doc.at_css("div"))
       node.scrub!(:strip)
     end
 
     it "scrubs document nodesets" do
-      doc = Loofah.document(HTML)
+      doc = Loofah.document(html)
       assert(node_set = doc.css("div"))
       assert_instance_of Nokogiri::XML::NodeSet, node_set
       node_set.scrub!(:strip)
     end
 
     it "scrubs fragment nodesets" do
-      doc = Loofah.fragment(HTML)
+      doc = Loofah.fragment(html)
       assert(node_set = doc.css("div"))
       assert_instance_of Nokogiri::XML::NodeSet, node_set
       node_set.scrub!(:strip)
     end
 
-    it "exposes serialize_root on HTML::DocumentFragment" do
-      doc = Loofah.fragment(HTML)
-      assert_equal HTML, doc.serialize_root.to_html
+    it "exposes serialize_root on Loofah::HTML::DocumentFragment" do
+      doc = Loofah.fragment(html)
+      assert_equal html, doc.serialize_root.to_html
     end
 
-    it "exposes serialize_root on HTML::Document" do
-      doc = Loofah.document(HTML)
-      assert_equal HTML, doc.serialize_root.children.to_html
+    it "exposes serialize_root on Loofah::HTML::Document" do
+      doc = Loofah.document(html)
+      assert_equal html, doc.serialize_root.children.to_html
     end
   end
 
-  describe "XML" do
+  describe Loofah::XML do
     it "creates documents" do
-      doc = Loofah.xml_document(XML)
+      doc = Loofah.xml_document(xml)
       assert_xml_documentish doc
     end
 
     it "creates fragments" do
-      doc = Loofah.xml_fragment(XML_FRAGMENT)
+      doc = Loofah.xml_fragment(xml_fragment)
       assert_xml_fragmentish doc
     end
 
     it "parses documents" do
-      doc = Loofah::XML::Document.parse(XML)
+      doc = Loofah::XML::Document.parse(xml)
       assert_xml_documentish doc
     end
 
     it "parses document fragments" do
-      doc = Loofah::XML::DocumentFragment.parse(XML_FRAGMENT)
+      doc = Loofah::XML::DocumentFragment.parse(xml_fragment)
       assert_xml_fragmentish doc
     end
 
     it "scrubs documents" do
       scrubber = Loofah::Scrubber.new { |node| }
-      doc = Loofah.xml_document(XML).scrub!(scrubber)
+      doc = Loofah.xml_document(xml).scrub!(scrubber)
       assert_xml_documentish doc
     end
 
     it "scrubs fragments" do
       scrubber = Loofah::Scrubber.new { |node| }
-      doc = Loofah.xml_fragment(XML_FRAGMENT).scrub!(scrubber)
+      doc = Loofah.xml_fragment(xml_fragment).scrub!(scrubber)
       assert_xml_fragmentish doc
     end
 
     it "scrubs document nodes" do
-      doc = Loofah.xml_document(XML)
+      doc = Loofah.xml_document(xml)
       assert(node = doc.at_css("div"))
       node.scrub!(:strip)
     end
 
     it "scrubs fragment nodes" do
-      doc = Loofah.xml_fragment(XML)
+      doc = Loofah.xml_fragment(xml)
       assert(node = doc.at_css("div"))
       node.scrub!(:strip)
     end
 
     it "scrubs document nodesets" do
-      doc = Loofah.xml_document(XML)
+      doc = Loofah.xml_document(xml)
       assert(node_set = doc.css("div"))
       assert_instance_of Nokogiri::XML::NodeSet, node_set
       node_set.scrub!(:strip)
@@ -129,26 +129,26 @@ class UnitTestApi < Loofah::TestCase
   private
 
   def assert_html_documentish(doc)
-    assert_kind_of Nokogiri::HTML::Document, doc
+    assert_kind_of Nokogiri::HTML4::Document, doc
     assert_kind_of Loofah::HTML::Document, doc
-    assert_equal HTML, doc.xpath("/html/body").inner_html
+    assert_equal html, doc.xpath("/html/body").inner_html
   end
 
   def assert_html_fragmentish(doc)
-    assert_kind_of Nokogiri::HTML::DocumentFragment, doc
+    assert_kind_of Nokogiri::HTML4::DocumentFragment, doc
     assert_kind_of Loofah::HTML::DocumentFragment, doc
-    assert_equal HTML, doc.inner_html
+    assert_equal html, doc.inner_html
   end
 
   def assert_xml_documentish(doc)
     assert_kind_of Nokogiri::XML::Document, doc
     assert_kind_of Loofah::XML::Document, doc
-    assert_equal XML, doc.root.to_xml
+    assert_equal xml, doc.root.to_xml
   end
 
   def assert_xml_fragmentish(doc)
     assert_kind_of Nokogiri::XML::DocumentFragment, doc
     assert_kind_of Loofah::XML::DocumentFragment, doc
-    assert_equal XML_FRAGMENT, doc.children.to_xml
+    assert_equal xml_fragment, doc.children.to_xml
   end
 end

--- a/test/unit/test_api.rb
+++ b/test/unit/test_api.rb
@@ -64,28 +64,37 @@ class UnitTestApi < Loofah::TestCase
     end
 
     describe "html5 methods" do
-      it "creates html5 documents" do
-        doc = Loofah.html5_document(html)
-        assert_kind_of(Loofah::HTML5::Document, doc)
-        assert_equal html, doc.xpath("/html/body").inner_html
-      end
+      if Loofah.html5_support?
+        it "creates html5 documents" do
+          doc = Loofah.html5_document(html)
+          assert_kind_of(Loofah::HTML5::Document, doc)
+          assert_equal html, doc.xpath("/html/body").inner_html
+        end
 
-      it "scrubs html5 documents" do
-        doc = Loofah.scrub_html5_document(html, :strip)
-        assert_kind_of(Loofah::HTML5::Document, doc)
-        assert_equal html, doc.xpath("/html/body").inner_html
-      end
+        it "scrubs html5 documents" do
+          doc = Loofah.scrub_html5_document(html, :strip)
+          assert_kind_of(Loofah::HTML5::Document, doc)
+          assert_equal html, doc.xpath("/html/body").inner_html
+        end
 
-      it "creates html5 fragments" do
-        doc = Loofah.html5_fragment(html)
-        assert_kind_of(Loofah::HTML5::DocumentFragment, doc)
-        assert_equal html, doc.inner_html
-      end
+        it "creates html5 fragments" do
+          doc = Loofah.html5_fragment(html)
+          assert_kind_of(Loofah::HTML5::DocumentFragment, doc)
+          assert_equal html, doc.inner_html
+        end
 
-      it "scrubs html5 fragments" do
-        doc = Loofah.scrub_html5_fragment(html, :strip)
-        assert_kind_of(Loofah::HTML5::DocumentFragment, doc)
-        assert_equal html, doc.inner_html
+        it "scrubs html5 fragments" do
+          doc = Loofah.scrub_html5_fragment(html, :strip)
+          assert_kind_of(Loofah::HTML5::DocumentFragment, doc)
+          assert_equal html, doc.inner_html
+        end
+      else
+        it "raises an error" do
+          assert_raises(NotImplementedError) { Loofah.html5_document(html) }
+          assert_raises(NotImplementedError) { Loofah.scrub_html5_document(html, :strip) }
+          assert_raises(NotImplementedError) { Loofah.html5_fragment(html) }
+          assert_raises(NotImplementedError) { Loofah.scrub_html5_fragment(html, :strip) }
+        end
       end
     end
 

--- a/test/unit/test_encoding.rb
+++ b/test/unit/test_encoding.rb
@@ -5,12 +5,14 @@ class UnitTestEncoding < Loofah::TestCase
   UTF8_STRING = "日本語"
 
   if String.new.respond_to?(:encoding)
-    describe "scrub_fragment" do
+    describe "#scrub_html4_fragment" do
       it "sets the encoding for html" do
-        escaped = Loofah.scrub_fragment(UTF8_STRING, :escape).to_s
+        escaped = Loofah.scrub_html4_fragment(UTF8_STRING, :escape).to_s
         assert_equal UTF8_STRING.encoding, escaped.encoding
       end
+    end
 
+    describe "#scrub_xml_fragment" do
       it "sets the encoding for xml" do
         escaped = Loofah.scrub_xml_fragment(UTF8_STRING, :escape).to_s
         assert_equal UTF8_STRING.encoding, escaped.encoding

--- a/test/unit/test_encoding.rb
+++ b/test/unit/test_encoding.rb
@@ -12,6 +12,13 @@ class UnitTestEncoding < Loofah::TestCase
       end
     end
 
+    describe "#scrub_html5_fragment" do
+      it "sets the encoding for html" do
+        escaped = Loofah.scrub_html5_fragment(UTF8_STRING, :escape).to_s
+        assert_equal UTF8_STRING.encoding, escaped.encoding
+      end
+    end
+
     describe "#scrub_xml_fragment" do
       it "sets the encoding for xml" do
         escaped = Loofah.scrub_xml_fragment(UTF8_STRING, :escape).to_s

--- a/test/unit/test_encoding.rb
+++ b/test/unit/test_encoding.rb
@@ -17,7 +17,7 @@ class UnitTestEncoding < Loofah::TestCase
         escaped = Loofah.scrub_html5_fragment(UTF8_STRING, :escape).to_s
         assert_equal UTF8_STRING.encoding, escaped.encoding
       end
-    end
+    end if Loofah.html5_support?
 
     describe "#scrub_xml_fragment" do
       it "sets the encoding for xml" do

--- a/test/unit/test_helpers.rb
+++ b/test/unit/test_helpers.rb
@@ -5,10 +5,11 @@ class UnitTestHelpers < Loofah::TestCase
 
   describe "Helpers" do
     context ".strip_tags" do
-      it "invoke Loofah.fragment.text" do
+      it "invokes Loofah.html4_fragment.text" do
         mock_doc = MiniTest::Mock.new
         mock_doc.expect(:text, "string_value", [])
-        Loofah.stub(:fragment, mock_doc) do
+
+        Loofah.stub(:html4_fragment, mock_doc) do
           Loofah::Helpers.strip_tags(HTML_STRING)
         end
 
@@ -17,13 +18,13 @@ class UnitTestHelpers < Loofah::TestCase
     end
 
     context ".sanitize" do
-      it "invoke Loofah.scrub_fragment(:strip).to_s" do
+      it "invokes Loofah.scrub_html4_fragment(input, :strip).to_s" do
         mock_doc = MiniTest::Mock.new
         mock_doc.expect(:scrub!, mock_doc, [:strip])
         mock_doc.expect(:xpath, [], ["./form"])
         mock_doc.expect(:to_s, "string_value", [])
 
-        Loofah.stub(:fragment, mock_doc) do
+        Loofah.stub(:html4_fragment, mock_doc) do
           Loofah::Helpers.sanitize(HTML_STRING)
         end
 

--- a/test/unit/test_scrubber.rb
+++ b/test/unit/test_scrubber.rb
@@ -21,13 +21,23 @@ class UnitTestScrubber < Loofah::TestCase
         end
       end
 
-      it "operate properly on a fragment" do
+      it "operates properly" do
         Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_COUNT, @count
       end
 
-      it "operate properly on a document" do
+      it "operates properly" do
         Loofah.scrub_html4_document(DOCUMENT, @scrubber)
+        assert_equal DOCUMENT_NODE_COUNT, @count
+      end
+
+      it "operates properly" do
+        Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
+        assert_equal FRAGMENT_NODE_COUNT, @count
+      end
+
+      it "operates properly" do
+        Loofah.scrub_html5_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_COUNT, @count
       end
     end
@@ -40,13 +50,23 @@ class UnitTestScrubber < Loofah::TestCase
         end
       end
 
-      it "operate as top-down on a fragment" do
+      it "operates as top-down" do
         Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_STOP_TOP_DOWN, @count
       end
 
-      it "operate as top-down on a document" do
+      it "operates as top-down" do
         Loofah.scrub_html4_document(DOCUMENT, @scrubber)
+        assert_equal DOCUMENT_NODE_STOP_TOP_DOWN, @count
+      end
+
+      it "operates as top-down" do
+        Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
+        assert_equal FRAGMENT_NODE_STOP_TOP_DOWN, @count
+      end
+
+      it "operates as top-down" do
+        Loofah.scrub_html5_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_STOP_TOP_DOWN, @count
       end
     end
@@ -58,9 +78,24 @@ class UnitTestScrubber < Loofah::TestCase
         end
       end
 
-      it "act as if CONTINUE was returned" do
+      it "acts as if CONTINUE was returned" do
         Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_COUNT, @count
+      end
+
+      it "acts as if CONTINUE was returned" do
+        Loofah.scrub_html4_document(DOCUMENT, @scrubber)
+        assert_equal DOCUMENT_NODE_COUNT, @count
+      end
+
+      it "acts as if CONTINUE was returned" do
+        Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
+        assert_equal FRAGMENT_NODE_COUNT, @count
+      end
+
+      it "acts as if CONTINUE was returned" do
+        Loofah.scrub_html5_document(DOCUMENT, @scrubber)
+        assert_equal DOCUMENT_NODE_COUNT, @count
       end
     end
 
@@ -72,13 +107,23 @@ class UnitTestScrubber < Loofah::TestCase
         end
       end
 
-      it "operate as top-down on a fragment" do
+      it "operates as top-down" do
         Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_STOP_TOP_DOWN, @count
       end
 
-      it "operate as top-down on a document" do
+      it "operates as top-down" do
         Loofah.scrub_html4_document(DOCUMENT, @scrubber)
+        assert_equal DOCUMENT_NODE_STOP_TOP_DOWN, @count
+      end
+
+      it "operates as top-down" do
+        Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
+        assert_equal FRAGMENT_NODE_STOP_TOP_DOWN, @count
+      end
+
+      it "operates as top-down" do
+        Loofah.scrub_html5_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_STOP_TOP_DOWN, @count
       end
     end
@@ -91,13 +136,23 @@ class UnitTestScrubber < Loofah::TestCase
         end
       end
 
-      it "operate as top-down on a fragment" do
+      it "operates as top-down" do
         Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_STOP_TOP_DOWN, @count
       end
 
-      it "operate as top-down on a document" do
+      it "operates as top-down" do
         Loofah.scrub_html4_document(DOCUMENT, @scrubber)
+        assert_equal DOCUMENT_NODE_STOP_TOP_DOWN, @count
+      end
+
+      it "operates as top-down" do
+        Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
+        assert_equal FRAGMENT_NODE_STOP_TOP_DOWN, @count
+      end
+
+      it "operates as top-down" do
+        Loofah.scrub_html5_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_STOP_TOP_DOWN, @count
       end
     end
@@ -109,13 +164,23 @@ class UnitTestScrubber < Loofah::TestCase
         end
       end
 
-      it "operate as bottom-up on a fragment" do
+      it "operates as bottom-up" do
         Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_COUNT, @count
       end
 
-      it "operate as bottom-up on a document" do
+      it "operates as bottom-up" do
         Loofah.scrub_html4_document(DOCUMENT, @scrubber)
+        assert_equal DOCUMENT_NODE_COUNT, @count
+      end
+
+      it "operates as bottom-up" do
+        Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
+        assert_equal FRAGMENT_NODE_COUNT, @count
+      end
+
+      it "operates as bottom-up" do
+        Loofah.scrub_html5_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_COUNT, @count
       end
     end
@@ -135,9 +200,24 @@ class UnitTestScrubber < Loofah::TestCase
         end
       end
 
-      it "work anyway, shrug" do
+      it "works anyway, shrug" do
         Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_COUNT, @count
+      end
+
+      it "works anyway, shrug" do
+        Loofah.scrub_html4_document(DOCUMENT, @scrubber)
+        assert_equal DOCUMENT_NODE_COUNT, @count
+      end
+
+      it "works anyway, shrug" do
+        Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
+        assert_equal FRAGMENT_NODE_COUNT, @count
+      end
+
+      it "works anyway, shrug" do
+        Loofah.scrub_html5_document(DOCUMENT, @scrubber)
+        assert_equal DOCUMENT_NODE_COUNT, @count
       end
     end
   end
@@ -165,13 +245,23 @@ class UnitTestScrubber < Loofah::TestCase
         assert_nil @scrubber.direction
       end
 
-      it "operate as top-down on a fragment" do
+      it "operates as top-down" do
         Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_STOP_TOP_DOWN, @scrubber.count
       end
 
-      it "operate as top-down on a document" do
+      it "operates as top-down" do
         Loofah.scrub_html4_document(DOCUMENT, @scrubber)
+        assert_equal DOCUMENT_NODE_STOP_TOP_DOWN, @scrubber.count
+      end
+
+      it "operates as top-down" do
+        Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
+        assert_equal FRAGMENT_NODE_STOP_TOP_DOWN, @scrubber.count
+      end
+
+      it "operates as top-down" do
+        Loofah.scrub_html5_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_STOP_TOP_DOWN, @scrubber.count
       end
     end
@@ -182,13 +272,23 @@ class UnitTestScrubber < Loofah::TestCase
         assert_equal :top_down, @scrubber.direction
       end
 
-      it "operate as top-down on a fragment" do
+      it "operates as top-down" do
         Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_STOP_TOP_DOWN, @scrubber.count
       end
 
-      it "operate as top-down on a document" do
+      it "operates as top-down" do
         Loofah.scrub_html4_document(DOCUMENT, @scrubber)
+        assert_equal DOCUMENT_NODE_STOP_TOP_DOWN, @scrubber.count
+      end
+
+      it "operates as top-down" do
+        Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
+        assert_equal FRAGMENT_NODE_STOP_TOP_DOWN, @scrubber.count
+      end
+
+      it "operates as top-down" do
+        Loofah.scrub_html5_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_STOP_TOP_DOWN, @scrubber.count
       end
     end
@@ -199,13 +299,23 @@ class UnitTestScrubber < Loofah::TestCase
         assert_equal :bottom_up, @scrubber.direction
       end
 
-      it "operate as bottom-up on a fragment" do
+      it "operates as bottom-up" do
         Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_COUNT, @scrubber.count
       end
 
-      it "operate as bottom-up on a document" do
+      it "operates as bottom-up" do
         Loofah.scrub_html4_document(DOCUMENT, @scrubber)
+        assert_equal DOCUMENT_NODE_COUNT, @scrubber.count
+      end
+
+      it "operates as bottom-up" do
+        Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
+        assert_equal FRAGMENT_NODE_COUNT, @scrubber.count
+      end
+
+      it "operates as bottom-up" do
+        Loofah.scrub_html5_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_COUNT, @scrubber.count
       end
     end
@@ -219,9 +329,21 @@ class UnitTestScrubber < Loofah::TestCase
       @scrubber = @klass.new
     end
 
-    it "raise an exception" do
+    it "raises an exception" do
       assert_raises(Loofah::ScrubberNotFound) {
         Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
+      }
+
+      assert_raises(Loofah::ScrubberNotFound) {
+        Loofah.scrub_html4_document(DOCUMENT, @scrubber)
+      }
+
+      assert_raises(Loofah::ScrubberNotFound) {
+        Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
+      }
+
+      assert_raises(Loofah::ScrubberNotFound) {
+        Loofah.scrub_html5_document(DOCUMENT, @scrubber)
       }
     end
   end

--- a/test/unit/test_scrubber.rb
+++ b/test/unit/test_scrubber.rb
@@ -22,12 +22,12 @@ class UnitTestScrubber < Loofah::TestCase
       end
 
       it "operate properly on a fragment" do
-        Loofah.scrub_fragment(FRAGMENT, @scrubber)
+        Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_COUNT, @count
       end
 
       it "operate properly on a document" do
-        Loofah.scrub_document(DOCUMENT, @scrubber)
+        Loofah.scrub_html4_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_COUNT, @count
       end
     end
@@ -41,12 +41,12 @@ class UnitTestScrubber < Loofah::TestCase
       end
 
       it "operate as top-down on a fragment" do
-        Loofah.scrub_fragment(FRAGMENT, @scrubber)
+        Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_STOP_TOP_DOWN, @count
       end
 
       it "operate as top-down on a document" do
-        Loofah.scrub_document(DOCUMENT, @scrubber)
+        Loofah.scrub_html4_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_STOP_TOP_DOWN, @count
       end
     end
@@ -59,7 +59,7 @@ class UnitTestScrubber < Loofah::TestCase
       end
 
       it "act as if CONTINUE was returned" do
-        Loofah.scrub_fragment(FRAGMENT, @scrubber)
+        Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_COUNT, @count
       end
     end
@@ -73,12 +73,12 @@ class UnitTestScrubber < Loofah::TestCase
       end
 
       it "operate as top-down on a fragment" do
-        Loofah.scrub_fragment(FRAGMENT, @scrubber)
+        Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_STOP_TOP_DOWN, @count
       end
 
       it "operate as top-down on a document" do
-        Loofah.scrub_document(DOCUMENT, @scrubber)
+        Loofah.scrub_html4_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_STOP_TOP_DOWN, @count
       end
     end
@@ -92,12 +92,12 @@ class UnitTestScrubber < Loofah::TestCase
       end
 
       it "operate as top-down on a fragment" do
-        Loofah.scrub_fragment(FRAGMENT, @scrubber)
+        Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_STOP_TOP_DOWN, @count
       end
 
       it "operate as top-down on a document" do
-        Loofah.scrub_document(DOCUMENT, @scrubber)
+        Loofah.scrub_html4_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_STOP_TOP_DOWN, @count
       end
     end
@@ -110,12 +110,12 @@ class UnitTestScrubber < Loofah::TestCase
       end
 
       it "operate as bottom-up on a fragment" do
-        Loofah.scrub_fragment(FRAGMENT, @scrubber)
+        Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_COUNT, @count
       end
 
       it "operate as bottom-up on a document" do
-        Loofah.scrub_document(DOCUMENT, @scrubber)
+        Loofah.scrub_html4_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_COUNT, @count
       end
     end
@@ -136,7 +136,7 @@ class UnitTestScrubber < Loofah::TestCase
       end
 
       it "work anyway, shrug" do
-        Loofah.scrub_fragment(FRAGMENT, @scrubber)
+        Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_COUNT, @count
       end
     end
@@ -166,12 +166,12 @@ class UnitTestScrubber < Loofah::TestCase
       end
 
       it "operate as top-down on a fragment" do
-        Loofah.scrub_fragment(FRAGMENT, @scrubber)
+        Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_STOP_TOP_DOWN, @scrubber.count
       end
 
       it "operate as top-down on a document" do
-        Loofah.scrub_document(DOCUMENT, @scrubber)
+        Loofah.scrub_html4_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_STOP_TOP_DOWN, @scrubber.count
       end
     end
@@ -183,12 +183,12 @@ class UnitTestScrubber < Loofah::TestCase
       end
 
       it "operate as top-down on a fragment" do
-        Loofah.scrub_fragment(FRAGMENT, @scrubber)
+        Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_STOP_TOP_DOWN, @scrubber.count
       end
 
       it "operate as top-down on a document" do
-        Loofah.scrub_document(DOCUMENT, @scrubber)
+        Loofah.scrub_html4_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_STOP_TOP_DOWN, @scrubber.count
       end
     end
@@ -200,12 +200,12 @@ class UnitTestScrubber < Loofah::TestCase
       end
 
       it "operate as bottom-up on a fragment" do
-        Loofah.scrub_fragment(FRAGMENT, @scrubber)
+        Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_COUNT, @scrubber.count
       end
 
       it "operate as bottom-up on a document" do
-        Loofah.scrub_document(DOCUMENT, @scrubber)
+        Loofah.scrub_html4_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_COUNT, @scrubber.count
       end
     end
@@ -221,7 +221,7 @@ class UnitTestScrubber < Loofah::TestCase
 
     it "raise an exception" do
       assert_raises(Loofah::ScrubberNotFound) {
-        Loofah.scrub_fragment(FRAGMENT, @scrubber)
+        Loofah.scrub_html4_fragment(FRAGMENT, @scrubber)
       }
     end
   end

--- a/test/unit/test_scrubber.rb
+++ b/test/unit/test_scrubber.rb
@@ -34,12 +34,12 @@ class UnitTestScrubber < Loofah::TestCase
       it "operates properly" do
         Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_COUNT, @count
-      end
+      end if Loofah.html5_support?
 
       it "operates properly" do
         Loofah.scrub_html5_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_COUNT, @count
-      end
+      end if Loofah.html5_support?
     end
 
     context "returning STOP" do
@@ -63,12 +63,12 @@ class UnitTestScrubber < Loofah::TestCase
       it "operates as top-down" do
         Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_STOP_TOP_DOWN, @count
-      end
+      end if Loofah.html5_support?
 
       it "operates as top-down" do
         Loofah.scrub_html5_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_STOP_TOP_DOWN, @count
-      end
+      end if Loofah.html5_support?
     end
 
     context "returning neither CONTINUE nor STOP" do
@@ -91,12 +91,12 @@ class UnitTestScrubber < Loofah::TestCase
       it "acts as if CONTINUE was returned" do
         Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_COUNT, @count
-      end
+      end if Loofah.html5_support?
 
       it "acts as if CONTINUE was returned" do
         Loofah.scrub_html5_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_COUNT, @count
-      end
+      end if Loofah.html5_support?
     end
 
     context "not specifying direction" do
@@ -120,12 +120,12 @@ class UnitTestScrubber < Loofah::TestCase
       it "operates as top-down" do
         Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_STOP_TOP_DOWN, @count
-      end
+      end if Loofah.html5_support?
 
       it "operates as top-down" do
         Loofah.scrub_html5_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_STOP_TOP_DOWN, @count
-      end
+      end if Loofah.html5_support?
     end
 
     context "specifying top-down direction" do
@@ -149,12 +149,12 @@ class UnitTestScrubber < Loofah::TestCase
       it "operates as top-down" do
         Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_STOP_TOP_DOWN, @count
-      end
+      end if Loofah.html5_support?
 
       it "operates as top-down" do
         Loofah.scrub_html5_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_STOP_TOP_DOWN, @count
-      end
+      end if Loofah.html5_support?
     end
 
     context "specifying bottom-up direction" do
@@ -177,12 +177,12 @@ class UnitTestScrubber < Loofah::TestCase
       it "operates as bottom-up" do
         Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_COUNT, @count
-      end
+      end if Loofah.html5_support?
 
       it "operates as bottom-up" do
         Loofah.scrub_html5_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_COUNT, @count
-      end
+      end if Loofah.html5_support?
     end
 
     context "invalid direction" do
@@ -213,12 +213,12 @@ class UnitTestScrubber < Loofah::TestCase
       it "works anyway, shrug" do
         Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_COUNT, @count
-      end
+      end if Loofah.html5_support?
 
       it "works anyway, shrug" do
         Loofah.scrub_html5_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_COUNT, @count
-      end
+      end if Loofah.html5_support?
     end
   end
 
@@ -258,12 +258,12 @@ class UnitTestScrubber < Loofah::TestCase
       it "operates as top-down" do
         Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_STOP_TOP_DOWN, @scrubber.count
-      end
+      end if Loofah.html5_support?
 
       it "operates as top-down" do
         Loofah.scrub_html5_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_STOP_TOP_DOWN, @scrubber.count
-      end
+      end if Loofah.html5_support?
     end
 
     context "when direction is specified as top_down" do
@@ -285,12 +285,12 @@ class UnitTestScrubber < Loofah::TestCase
       it "operates as top-down" do
         Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_STOP_TOP_DOWN, @scrubber.count
-      end
+      end if Loofah.html5_support?
 
       it "operates as top-down" do
         Loofah.scrub_html5_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_STOP_TOP_DOWN, @scrubber.count
-      end
+      end if Loofah.html5_support?
     end
 
     context "when direction is specified as bottom_up" do
@@ -312,12 +312,12 @@ class UnitTestScrubber < Loofah::TestCase
       it "operates as bottom-up" do
         Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
         assert_equal FRAGMENT_NODE_COUNT, @scrubber.count
-      end
+      end if Loofah.html5_support?
 
       it "operates as bottom-up" do
         Loofah.scrub_html5_document(DOCUMENT, @scrubber)
         assert_equal DOCUMENT_NODE_COUNT, @scrubber.count
-      end
+      end if Loofah.html5_support?
     end
   end
 
@@ -340,11 +340,11 @@ class UnitTestScrubber < Loofah::TestCase
 
       assert_raises(Loofah::ScrubberNotFound) {
         Loofah.scrub_html5_fragment(FRAGMENT, @scrubber)
-      }
+      } if Loofah.html5_support?
 
       assert_raises(Loofah::ScrubberNotFound) {
         Loofah.scrub_html5_document(DOCUMENT, @scrubber)
-      }
+      } if Loofah.html5_support?
     end
   end
 end

--- a/test/unit/test_scrubbers.rb
+++ b/test/unit/test_scrubbers.rb
@@ -1,12 +1,7 @@
 require "helper"
 
 class UnitTestScrubbers < Loofah::TestCase
-  [
-    Loofah::HTML4::Document,
-    Loofah::HTML4::DocumentFragment,
-    Loofah::HTML5::Document,
-    Loofah::HTML5::DocumentFragment,
-  ].each do |klass|
+  [LOOFAH_HTML_DOCUMENT_CLASSES, LOOFAH_HTML_DOCUMENT_CLASSES].flatten.each do |klass|
     context klass do
       context "bad scrub method" do
         it "raise a ScrubberNotFound exception" do

--- a/test/unit/test_scrubbers.rb
+++ b/test/unit/test_scrubbers.rb
@@ -1,7 +1,7 @@
 require "helper"
 
 class UnitTestScrubbers < Loofah::TestCase
-  [Loofah::HTML::Document, Loofah::HTML::DocumentFragment].each do |klass|
+  [Loofah::HTML4::Document, Loofah::HTML4::DocumentFragment].each do |klass|
     context klass do
       context "bad scrub method" do
         it "raise a ScrubberNotFound exception" do

--- a/test/unit/test_scrubbers.rb
+++ b/test/unit/test_scrubbers.rb
@@ -1,7 +1,12 @@
 require "helper"
 
 class UnitTestScrubbers < Loofah::TestCase
-  [Loofah::HTML4::Document, Loofah::HTML4::DocumentFragment].each do |klass|
+  [
+    Loofah::HTML4::Document,
+    Loofah::HTML4::DocumentFragment,
+    Loofah::HTML5::Document,
+    Loofah::HTML5::DocumentFragment,
+  ].each do |klass|
     context klass do
       context "bad scrub method" do
         it "raise a ScrubberNotFound exception" do


### PR DESCRIPTION
The libgumbo parser used by Nokogiri::HTML5 is superior, standards-wise, to the libxml2 parser used by Nokogiri::HTML4 (the default).

This PR replaces #239. It has a much more flexible API that provides both html4 and html5 methods. It's up to the caller to choose which they want (note that the generic calls like `Loofah.fragment` still default to HTML4).

- [x] rename generic html methods with a `html4` name, and alias the generic method names to them
- [x] introduce HTML5 functionality
- [x] get JRuby green (!)
- [x] ~add a CI job to test against an older version of Nokogiri to ensure backwards-compatibility~

Note that testing in CI with older Rubies is sufficient to test older versions of Nokogiri, because Ruby 2.5 and 2.6 use Nokogiri 1.12 and 1.13, respectively, for precompiled binaries.
