### PR TITLE
test: support libxml 2.10.4 behavior around namespaces

### DIFF
--- a/test/integration/test_ad_hoc.rb
+++ b/test/integration/test_ad_hoc.rb
@@ -130,7 +130,7 @@ class IntegrationTestAdHoc < Loofah::TestCase
 
         def test_fragment_whitewash_on_microsofty_markup
           whitewashed = fragment(MSWORD_HTML).scrub!(:whitewash)
-          expected = if Nokogiri.uses_libxml?("<2.9.11") || html_version == :html5
+          expected = if Nokogiri.uses_libxml?("<2.9.11") || Nokogiri.uses_libxml?(">=2.10.4") || html_version == :html5
             "<p>Foo <b>BOLD</b></p>"
           elsif Nokogiri.jruby?
             "<p>Foo <b>BOLD<o:p></o:p></b></p>"
@@ -143,7 +143,7 @@ class IntegrationTestAdHoc < Loofah::TestCase
 
         def test_document_whitewash_on_microsofty_markup
           whitewashed = document(MSWORD_HTML).scrub!(:whitewash)
-          expected = if Nokogiri.uses_libxml?("<2.9.11") || html_version == :html5
+          expected = if Nokogiri.uses_libxml?("<2.9.11") || Nokogiri.uses_libxml?(">=2.10.4") || html_version == :html5
             "<p>Foo <b>BOLD</b></p>"
           elsif Nokogiri.jruby?
             "<p>Foo <b>BOLD<o:p></o:p></b></p>"

--- a/test/integration/test_scrubbers.rb
+++ b/test/integration/test_scrubbers.rb
@@ -159,7 +159,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
             doc = klass.parse("<html><body>#{WHITEWASH_FRAGMENT}</body></html>")
             result = doc.scrub!(:whitewash)
 
-            ww_result = if Nokogiri.uses_libxml?("<2.9.11") || html5?
+            ww_result = if Nokogiri.uses_libxml?("<2.9.11") || Nokogiri.uses_libxml?(">=2.10.4") || html5?
               WHITEWASH_RESULT
             elsif Nokogiri.jruby?
               WHITEWASH_RESULT_JRUBY
@@ -358,7 +358,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
             doc = klass.parse("<div>#{WHITEWASH_FRAGMENT}</div>")
             result = doc.scrub!(:whitewash)
 
-            ww_result = if Nokogiri.uses_libxml?("<2.9.11") || html5?
+            ww_result = if Nokogiri.uses_libxml?("<2.9.11") || Nokogiri.uses_libxml?(">=2.10.4") || html5?
               WHITEWASH_RESULT
             elsif Nokogiri.jruby?
               WHITEWASH_RESULT_JRUBY


### PR DESCRIPTION
see note in https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.10.4