### PR TITLE
don't define HTML5::Document and HTML5::DocumentFragment if HTML5 isn't supported

### DIFF
--- a/lib/loofah.rb
+++ b/lib/loofah.rb
@@ -123,19 +123,19 @@ module Loofah
       end
     else
       def html5_document(*args, &block)
-        raise NotImplementedError, "HTML5 is not supported by your version of Nokogiri"
+        raise NotImplementedError, "Loofah::HTML5 is not supported by your version of Nokogiri"
       end
 
       def html5_fragment(*args, &block)
-        raise NotImplementedError, "HTML5 is not supported by your version of Nokogiri"
+        raise NotImplementedError, "Loofah::HTML5 is not supported by your version of Nokogiri"
       end
 
       def scrub_html5_document(string_or_io, method)
-        raise NotImplementedError, "HTML5 is not supported by your version of Nokogiri"
+        raise NotImplementedError, "Loofah::HTML5 is not supported by your version of Nokogiri"
       end
 
       def scrub_html5_fragment(string_or_io, method)
-        raise NotImplementedError, "HTML5 is not supported by your version of Nokogiri"
+        raise NotImplementedError, "Loofah::HTML5 is not supported by your version of Nokogiri"
       end
     end
 

--- a/lib/loofah.rb
+++ b/lib/loofah.rb
@@ -36,7 +36,7 @@ require_relative "loofah/xml/document_fragment"
 require_relative "loofah/html4/document"
 require_relative "loofah/html4/document_fragment"
 
-if Nokogiri.respond_to?(:uses_gumbo?) && Nokogiri.uses_gumbo?
+if Loofah.html5_support?
   require_relative "loofah/html5/document"
   require_relative "loofah/html5/document_fragment"
 end

--- a/test/unit/test_api.rb
+++ b/test/unit/test_api.rb
@@ -109,6 +109,11 @@ class UnitTestApi < Loofah::TestCase
           assert_raises(NotImplementedError) { Loofah.html5_fragment(html) }
           assert_raises(NotImplementedError) { Loofah.scrub_html5_fragment(html, :strip) }
         end
+
+        it "does not implement classes" do
+          assert_raises(NameError) { Loofah::HTML5::Document }
+          assert_raises(NameError) { Loofah::HTML5::DocumentFragment }
+        end
       end
     end
 


### PR DESCRIPTION
These classes require Nokogiri v1.14 in order to work properly.