### PR TITLE
dep: require nokogiri >= 1.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,11 @@ These are not required automatically. You must require `loofah/helpers` to use t
 
 Unsurprisingly:
 
-* gem install loofah
+> gem install loofah
+
+Requirements:
+
+* Ruby >= 2.5
 
 
 ## Support

--- a/loofah.gemspec
+++ b/loofah.gemspec
@@ -42,6 +42,8 @@ Gem::Specification.new do |spec|
     ] + Dir.glob("lib/**/*.*")
   end
 
+  spec.required_ruby_version = ">= 2.5.0"
+
   spec.add_runtime_dependency("crass", ["~> 1.0.2"])
-  spec.add_runtime_dependency("nokogiri", [">= 1.5.9"])
+  spec.add_runtime_dependency("nokogiri", [">= 1.12.0"])
 end


### PR DESCRIPTION
Closes #266 

This PR updates the Nokogiri dependency to `>= 1.12.0`, and the Ruby dependency to `>= 2.5.0` (which matches the requirement of Nokogiri 1.12.x).
