### PR TITLE
dep: bump hoe-markdown for ruby 3.3 ci

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org/"
 gemspec
 
 group :development do
-  gem("hoe-markdown", ["~> 1.3"])
+  gem("hoe-markdown", ["~> 1.5", ">= 1.5.1"])
   gem("json", ["~> 2.2"])
   gem("minitest", ["~> 5.14"])
   gem("rake", ["~> 13.0"])


### PR DESCRIPTION
Pulls in fix from https://github.com/flavorjones/hoe-markdown/pull/1