### PR TITLE
feat: adds `:targetblank` scrubber

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Active Record extensions for HTML sanitization are available in the [`loofah-act
   * _Whitewash_ the markup, removing all attributes and namespaced nodes.
 * Other common HTML transformations are built-in:
   * Add the _nofollow_ attribute to all hyperlinks.
+  * Add the _target=\_blank_ attribute to all hyperlinks.
   * Remove _unprintable_ characters from text nodes.
 * Format markup as plain text, with (or without) sensible whitespace handling around block elements.
 * Replace Rails's `strip_tags` and `sanitize` view helper methods.
@@ -231,6 +232,7 @@ Loofah also comes with some common transformation tasks:
 ``` ruby
 doc.scrub!(:nofollow)    #     adds rel="nofollow" attribute to links
 doc.scrub!(:unprintable) #  removes unprintable characters from text nodes
+doc.scrub!(:targetblank) #     adds target="_blank" attribute to links
 ```
 
 See `Loofah::Scrubbers` for more details and example usage.

--- a/lib/loofah/scrubbers.rb
+++ b/lib/loofah/scrubbers.rb
@@ -61,6 +61,15 @@ module Loofah
   #     => "ohai! <a href='http://www.myswarmysite.com/' rel="nofollow">I like your blog post</a>"
   #
   #
+  #  === Loofah::Scrubbers::TargetBlank / scrub!(:targetblank)
+  #
+  #  +:targetblank+ adds a target="_blank" attribute to all links
+  #
+  #     link_farmers_markup = "ohai! <a href='http://www.myswarmysite.com/'>I like your blog post</a>"
+  #     Loofah.html5_fragment(link_farmers_markup).scrub!(:targetblank)
+  #     => "ohai! <a href='http://www.myswarmysite.com/' target="_blank">I like your blog post</a>"
+  #
+  #
   #  === Loofah::Scrubbers::NoOpener / scrub!(:noopener)
   #
   #  +:noopener+ adds a rel="noopener" attribute to all links
@@ -214,6 +223,33 @@ module Loofah
     end
 
     #
+    #  === scrub!(:targetblank)
+    #
+    #  +:targetblank+ adds a target="_blank" attribute to all links.
+    #  If there is a target already set, replaces it with target="_blank".
+    #
+    #     link_farmers_markup = "ohai! <a href='http://www.myswarmysite.com/'>I like your blog post</a>"
+    #     Loofah.html5_fragment(link_farmers_markup).scrub!(:targetblank)
+    #     => "ohai! <a href='http://www.myswarmysite.com/' target="_blank">I like your blog post</a>"
+    #
+    #  On modern browsers, setting target="_blank" on anchor elements implicitly provides the same
+    #  behavior as setting rel="noopener".
+    #
+    class TargetBlank < Scrubber
+      def initialize # rubocop:disable Lint/MissingSuper
+        @direction = :top_down
+      end
+
+      def scrub(node)
+        return CONTINUE unless (node.type == Nokogiri::XML::Node::ELEMENT_NODE) && (node.name == "a")
+
+        node.set_attribute("target", "_blank")
+
+        STOP
+      end
+    end
+
+    #
     #  === scrub!(:noopener)
     #
     #  +:noopener+ adds a rel="noopener" attribute to all links
@@ -292,6 +328,7 @@ module Loofah
       strip: Strip,
       nofollow: NoFollow,
       noopener: NoOpener,
+      targetblank: TargetBlank,
       newline_block_elements: NewlineBlockElements,
       unprintable: Unprintable,
     }

--- a/test/integration/test_scrubbers.rb
+++ b/test/integration/test_scrubbers.rb
@@ -16,6 +16,12 @@ class IntegrationTestScrubbers < Loofah::TestCase
   NOFOLLOW_FRAGMENT = '<a href="http://www.example.com/">Click here</a>'
   NOFOLLOW_RESULT = '<a href="http://www.example.com/" rel="nofollow">Click here</a>'
 
+  TARGET_FRAGMENT = '<a href="http://www.example.com/">Click here</a>'
+  TARGET_RESULT = '<a href="http://www.example.com/" target="_blank">Click here</a>'
+
+  TARGET_WITH_TOP_FRAGMENT = '<a href="http://www.example.com/" target="_top">Click here</a>'
+  TARGET_WITH_TOP_RESULT = '<a href="http://www.example.com/" target="_blank">Click here</a>'
+
   NOFOLLOW_WITH_REL_FRAGMENT = '<a href="http://www.example.com/" rel="noopener">Click here</a>'
   NOFOLLOW_WITH_REL_RESULT = '<a href="http://www.example.com/" rel="noopener nofollow">Click here</a>'
 
@@ -179,6 +185,28 @@ class IntegrationTestScrubbers < Loofah::TestCase
 
             assert_equal NOFOLLOW_RESULT, doc.xpath("/html/body").inner_html
             assert_equal doc, result
+          end
+        end
+
+        context ":targetblank" do
+          context "when target is not set" do
+            it "adds a target='_blank' attribute to hyperlinks" do
+              doc = klass.parse("<html><body>#{TARGET_FRAGMENT}</body></html>")
+              result = doc.scrub!(:targetblank)
+
+              assert_equal TARGET_RESULT, doc.xpath("/html/body").inner_html
+              assert_equal doc, result
+            end
+          end
+
+          context "when target is set" do
+            it "replaces existing 'target' attribute with '_blank' to hyperlinks" do
+              doc = klass.parse("<html><body>#{TARGET_WITH_TOP_FRAGMENT}</body></html>")
+              result = doc.scrub!(:targetblank)
+
+              assert_equal TARGET_WITH_TOP_RESULT, doc.xpath("/html/body").inner_html
+              assert_equal doc, result
+            end
           end
         end
 


### PR DESCRIPTION
[fixes #272]

New scrubber `:targetblank` - adds a `target="_blank"` attribute to all links. If there is a target already set, replaces it with `target="_blank"`.

```
  link_farmers_markup = "ohai! <a href='http://www.myswarmysite.com/'>I like your blog post</a>"
  Loofah.html5_fragment(link_farmers_markup).scrub!(:targetblank)
  => "ohai! <a href='http://www.myswarmysite.com/' target="_blank">I like your blog post</a>"
```

(co-authored by @thdaraujo)