### PR TITLE
Allow boolean and empty attributes for certain node types

### DIFF
--- a/lib/loofah/html5/safelist.rb
+++ b/lib/loofah/html5/safelist.rb
@@ -229,6 +229,154 @@ module Loofah
         "use",
       ])
 
+      ACCEPTABLE_EMPTY_ATTRIBUTES = {
+        "*" => Set.new([
+          "title",
+        ]),
+        "area" => Set.new([
+          "alt",
+        ]),
+        "audio" => Set.new([
+          "src",
+        ]),
+        "base" => Set.new([
+          "href",
+        ]),
+        "img" => Set.new([
+          "alt",
+        ]),
+        "input" => Set.new([
+          "value",
+          "placeholder",
+        ]),
+        "li" => Set.new([
+          "value",
+        ]),
+        "link" => Set.new([
+          "href",
+        ]),
+        "meter" => Set.new([
+          "value",
+        ]),
+        "option" => Set.new([
+          "value",
+        ]),
+        "progress" => Set.new([
+          "value",
+        ]),
+        "source" => Set.new([
+          "src",
+        ]),
+        "textarea" => Set.new([
+          "placeholder",
+        ]),
+        "track" => Set.new([
+          "default",
+        ]),
+      }
+
+      ACCEPTABLE_BOOLEAN_ATTRIBUTES = {
+        "*" => Set.new([
+          "hidden",
+          "contenteditable",
+          "draggable",
+          "spellcheck",
+          "translate",
+        ]),
+        "a" => Set.new([
+          "download",
+        ]),
+        "area" => Set.new([
+          "download",
+        ]),
+        "audio" => Set.new([
+          "autoplay",
+          "controls",
+          "loop",
+          "muted",
+        ]),
+        "button" => Set.new([
+          "autofocus",
+          "disabled",
+          "formnovalidate",
+        ]),
+        "details" => Set.new([
+          "open",
+        ]),
+        "fieldset" => Set.new([
+          "disabled",
+        ]),
+        "form" => Set.new([
+          "novalidate",
+        ]),
+        "iframe" => Set.new([
+          "allowfullscreen",
+          "seamless",
+        ]),
+        "img" => Set.new([
+          "alt",
+          "ismap",
+        ]),
+        "input" => Set.new([
+          "autofocus",
+          "checked",
+          "disabled",
+          "multiple",
+          "readonly",
+          "required",
+          "formnovalidate",
+        ]),
+        "ol" => Set.new([
+          "reversed",
+        ]),
+        "optgroup" => Set.new([
+          "disabled",
+        ]),
+        "option" => Set.new([
+          "disabled",
+          "selected",
+        ]),
+        "select" => Set.new([
+          "autofocus",
+          "disabled",
+          "multiple",
+          "required",
+        ]),
+        "style" => Set.new([
+          "scoped",
+        ]),
+        "table" => Set.new([
+          "sortable",
+        ]),
+        "td" => Set.new([
+          "nowrap",
+        ]),
+        "th" => Set.new([
+          "nowrap",
+        ]),
+        "textarea" => Set.new([
+          "autofocus",
+          "disabled",
+          "readonly",
+          "required",
+        ]),
+        "track" => Set.new([
+          "default",
+        ]),
+        "video" => Set.new([
+          "autoplay",
+          "controls",
+          "loop",
+          "muted",
+          "playsinline",
+        ]),
+      }
+
+      ACCEPTABLE_BOOLEAN_OR_EMPTY_ATTRIBUTES =
+        ACCEPTABLE_BOOLEAN_ATTRIBUTES.merge(ACCEPTABLE_EMPTY_ATTRIBUTES) do |_, a, b|
+          a + b
+        end
+
       ACCEPTABLE_ATTRIBUTES = Set.new([
         "abbr",
         "accept",

--- a/lib/loofah/html5/scrub.rb
+++ b/lib/loofah/html5/scrub.rb
@@ -32,7 +32,9 @@ module Loofah
               next
             end
 
-            unless SafeList::ALLOWED_ATTRIBUTES.include?(attr_name)
+            unless SafeList::ALLOWED_ATTRIBUTES.include?(attr_name) ||
+                SafeList::ACCEPTABLE_BOOLEAN_OR_EMPTY_ATTRIBUTES[node.name]&.include?(attr_node.name) ||
+                SafeList::ACCEPTABLE_BOOLEAN_OR_EMPTY_ATTRIBUTES["*"].include?(attr_node.name)
               attr_node.remove
               next
             end
@@ -56,9 +58,11 @@ module Loofah
           scrub_css_attribute(node)
 
           node.attribute_nodes.each do |attr_node|
-            if attr_node.value !~ /[^[:space:]]/ && attr_node.name !~ DATA_ATTRIBUTE_NAME
-              node.remove_attribute(attr_node.name)
-            end
+            next if attr_node.value =~ /[^[:space:]]/ || attr_node.name =~ DATA_ATTRIBUTE_NAME ||
+              SafeList::ACCEPTABLE_BOOLEAN_OR_EMPTY_ATTRIBUTES[node.name]&.include?(attr_node.name) ||
+              SafeList::ACCEPTABLE_BOOLEAN_OR_EMPTY_ATTRIBUTES["*"].include?(attr_node.name)
+
+            node.remove_attribute(attr_node.name)
           end
 
           force_correct_attribute_escaping!(node)

--- a/test/assets/testdata_sanitizer_tests1.dat
+++ b/test/assets/testdata_sanitizer_tests1.dat
@@ -526,5 +526,23 @@
     "name": "attributes_with_embedded_quotes_II",
     "input": "<img src=notthere.jpg\"\"onerror=\"alert(2) />",
     "libxml": "<img src='notthere.jpg%22%22onerror=%22alert(2)'>"
+  },
+
+  {
+    "name": "empty_attributes_1",
+    "input": "<option value=\"\">Empty Value<script>alert(1)</script></option>",
+    "libxml": "<option value=''>Empty Value&lt;script&gt;alert(1)&lt;/script&gt;</option>"
+  },
+
+  {
+    "name": "empty_attributes_2",
+    "input": "<option value=\"\">Empty Value</script></option>",
+    "libxml": "<option value=''>Empty Value</option>"
+  },
+
+  {
+    "name": "empty_attributes_3",
+    "input": "<option value=\"\" download=\"foo-bar\">Empty Value</option>",
+    "libxml": "<option value=''>Empty Value</option>"
   }
 ]

--- a/test/html5/test_sanitizer.rb
+++ b/test/html5/test_sanitizer.rb
@@ -200,6 +200,14 @@ class Html5TestSanitizer < Loofah::TestCase
     check_sanitization(input, output)
   end
 
+  def test_boolean_attributes
+    input = "<video controls download></video>"
+    expected_html5 = "<video controls=''></video>"
+    output_html5 = sanitize_html5(input).tr('"', "'")
+
+    assert_equal(expected_html5, output_html5)
+  end
+
   ##
   ##  libxml2 downcases attributes, so this is moot.
   ##


### PR DESCRIPTION
We are using Loofah in a number of projects where the scrubbing of empty attributes of boolean attributes became an issue. This PR adds support for boolean attributes or empty string values on certain node types. It fixes #242.

I.e. `<option value="">Empty Value</option>` is a perfectly safe html, but the empty value was stripped when using the scrubber. 

It also adds support for boolean attributes (i.e. `download` on an `<a>` element, or `autoplay` on a `<video>` tag. I could not get Nokogiri to output it as a boolean attributes, but the [html5 specification](https://www.w3.org/TR/2008/WD-html5-20080610/semantics.html) (section 3.2.2) specifies that empty string is also fine.

```
# Before this PR:
>> Loofah.html5_fragment('<option value="" selected></selected>').scrub!(:strip).to_s
=> "<option></option>"

# After this PR:
>> Loofah.html5_fragment('<option value="" selected></selected>').scrub!(:strip).to_s
=> "<option value=\"\" selected=\"\"></option>"
```

The behaviour from https://github.com/flavorjones/loofah/pull/51 is still the same, so the risk for unwanted regressions is minimal imho.

The tests on Github Action seem to [fail for truffleruby](https://github.com/zenjoy/loofah/actions/runs/7018950398). But that seems to be related to https://github.com/ruby/stringio/pull/71 which just got merged and not related to the actual code changes in this PR.

Feel free to make or suggest changes if needed. Thanks a lot for having a look at this!
