### PR TITLE
Pass block to document fragment instantiation

### DIFF
--- a/lib/loofah/concerns.rb
+++ b/lib/loofah/concerns.rb
@@ -168,13 +168,13 @@ module Loofah
 
   module HtmlFragmentBehavior # :nodoc:
     module ClassMethods
-      def parse(tags, encoding = nil)
+      def parse(tags, encoding = nil, &block)
         doc = document_klass.new
 
         encoding ||= tags.respond_to?(:encoding) ? tags.encoding.name : "UTF-8"
         doc.encoding = encoding
 
-        new(doc, tags)
+        new(doc, tags, &block)
       end
 
       def document_klass


### PR DESCRIPTION
Hi! I recently ran into a bizarre issue where some HTML I'm sanitizing was so deeply nested, that Nokogiri was silently failing with this error (`#<Nokogiri::XML::SyntaxError: 1153:513: FATAL: Excessive depth in document: 256 use XML_PARSE_HUGE option>`) and simply returning empty tags.

I'm looking into ways to potentially mitigate receiving HTML this deeply nested, but it also seems like it would be great if I could pass this option to Nokogiri to parse the HTML without losing a bunch of data.

I'm unsure if this would be the preferred way to introduce passing options from Loofah directly to Nokogiri, or if adding this sort of capability is something Loofah even wants to do, but I figured this would be a smaller change than adding an additional argument.

Anyway, thanks for all the work y'all do on this project. The company I work for has been using this for many years, and it continues to serve us well!