### PR TITLE
[RubyConf] Create scrubber for replacing double breakpoints into paragraph nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Active Record extensions for HTML sanitization are available in the [`loofah-act
   * Add the _nofollow_ attribute to all hyperlinks.
   * Add the _target=\_blank_ attribute to all hyperlinks.
   * Remove _unprintable_ characters from text nodes.
+  * Modify _double breakpoints_ characters to paragraph nodes.
 * Format markup as plain text, with (or without) sensible whitespace handling around block elements.
 * Replace Rails's `strip_tags` and `sanitize` view helper methods.
 
@@ -235,6 +236,7 @@ doc.scrub!(:noopener)    #  adds rel="noopener" attribute to links
 doc.scrub!(:noreferrer)  #  adds rel="noreferrer" attribute to links
 doc.scrub!(:unprintable) #  removes unprintable characters from text nodes
 doc.scrub!(:targetblank) #     adds target="_blank" attribute to links
+doc.scrub!(:double_breakpoint) #     removes double breakpoints to paragraph nodes
 ```
 
 See `Loofah::Scrubbers` for more details and example usage.

--- a/lib/loofah/scrubbers.rb
+++ b/lib/loofah/scrubbers.rb
@@ -365,7 +365,40 @@ module Loofah
       end
 
       def scrub(node)
-        
+        return CONTINUE unless (node.type == Nokogiri::XML::Node::ELEMENT_NODE) && (node.name == "p")
+
+        paragraph_with_break_point_nodes = node.xpath("//p[br[following-sibling::br]]")
+
+        paragraph_with_break_point_nodes.each do |paragraph_node|
+          new_paragraph = paragraph_node.add_previous_sibling("<p>").first
+
+          paragraph_node.children.each do |child|
+            remove_blank_text_nodes(child)
+          end
+
+          paragraph_node.children.each do |child|
+            # already unlinked
+            next if child.parent.nil?
+
+            if child.name == "br" && child.next_sibling.name == "br"
+              new_paragraph = paragraph_node.add_previous_sibling("<p>").first
+              child.next_sibling.unlink
+              child.unlink
+            else
+              child.parent = new_paragraph
+            end
+          end
+
+          paragraph_node.unlink
+        end
+
+        CONTINUE
+      end
+
+      private
+
+      def remove_blank_text_nodes(node)
+        node.unlink if node.text? && node.blank?
       end
     end
     #

--- a/lib/loofah/scrubbers.rb
+++ b/lib/loofah/scrubbers.rb
@@ -351,6 +351,24 @@ module Loofah
     end
 
     #
+    #  === scrub!(:double_breakpoint)
+    #
+    #  +:double_breakpoint+ replaces double-break tags with closing/opening paragraph tags.
+    #
+    #     double_breakpoint_markup = "<p>Some text here in a logical paragraph.<br><br>Some more text, apparently a second paragraph.</p>"
+    #     Loofah.html5_fragment(messy_markup).scrub!(:double_breakpoint)
+    #     => "<p>Some text here in a logical paragraph.</p><p>Some more text, apparently a second paragraph.</p>"
+    #
+    class DoubleBreakpoint < Scrubber
+      def initialize # rubocop:disable Lint/MissingSuper
+        @direction = :top_down
+      end
+
+      def scrub(node)
+        
+      end
+    end
+    #
     #  A hash that maps a symbol (like +:prune+) to the appropriate Scrubber (Loofah::Scrubbers::Prune).
     #
     MAP = {
@@ -364,6 +382,7 @@ module Loofah
       targetblank: TargetBlank,
       newline_block_elements: NewlineBlockElements,
       unprintable: Unprintable,
+      double_breakpoint: DoubleBreakpoint,
     }
 
     class << self

--- a/test/integration/test_scrubbers.rb
+++ b/test/integration/test_scrubbers.rb
@@ -245,7 +245,7 @@ class IntegrationTestScrubbers < Loofah::TestCase
             doc = klass.parse("<html><body>#{BREAKPOINT_FRAGMENT}</body></html>")
             result = doc.scrub!(:double_breakpoint)
 
-            assert_equal BREAKPOINT_RESULT, doc.xpath("/html/body").inner_html
+            assert_equal BREAKPOINT_RESULT, doc.xpath("/html/body").inner_html.delete("\n")
             assert_equal doc, result
           end
         end

--- a/test/integration/test_scrubbers.rb
+++ b/test/integration/test_scrubbers.rb
@@ -50,6 +50,9 @@ class IntegrationTestScrubbers < Loofah::TestCase
   ENTITY_HACK_ATTACK_TEXT_SCRUB = "Hack attack!&lt;script&gt;alert('evil')&lt;/script&gt;"
   ENTITY_HACK_ATTACK_TEXT_SCRUB_UNESC = "Hack attack!<script>alert('evil')</script>"
 
+  BREAKPOINT_FRAGMENT = "<p>Some text here in a logical paragraph.<br><br>Some more text, apparently a second paragraph.<br><br>Et cetera...</p>"
+  BREAKPOINT_RESULT = "<p>Some text here in a logical paragraph.</p><p>Some more text, apparently a second paragraph.</p><p>Et cetera...</p>"
+
   context "scrubbing shortcuts" do
     context "#scrub_document" do
       it "is a shortcut for parse-and-scrub" do
@@ -233,6 +236,16 @@ class IntegrationTestScrubbers < Loofah::TestCase
             result = doc.scrub!(:unprintable)
 
             assert_equal UNPRINTABLE_RESULT, doc.xpath("/html/body").inner_html
+            assert_equal doc, result
+          end
+        end
+
+        context ":double_breakpoint" do
+          it "replaces double line breaks with paragraph tags" do
+            doc = klass.parse("<html><body>#{BREAKPOINT_FRAGMENT}</body></html>")
+            result = doc.scrub!(:double_breakpoint)
+
+            assert_equal BREAKPOINT_RESULT, doc.xpath("/html/body").inner_html
             assert_equal doc, result
           end
         end


### PR DESCRIPTION
## Why?

- Users would like to have functionality within loofah that provides the ability to replace double breakpoints into paragraph nodes

## What?

- Creating a new scrubber (`:double_breakpoint`) that replaces double breakpoints into paragraph nodes (thank you @flavorjones )

## How did we test?

- Created a new integration test case. 

> [!IMPORTANT]  
> There is a failing test right now where the expectation and actual result match except for newline characters. In discussing with @flavorjones, this might be related to minitest and how it formats html

```sh
(ruby) doc.xpath("/html/body").inner_html
"<p>Some text here in a logical paragraph.</p><p>Some more text, apparently a second paragraph.</p><p>Et cetera...</p>"
(ruby) BREAKPOINT_RESULT
"<p>Some text here in a logical paragraph.</p><p>Some more text, apparently a second paragraph.</p><p>Et cetera...</p>"
(ruby) BREAKPOINT_RESULT == doc.xpath("/html/body").inner_html
```

References #279 