### PR TITLE
Add funding_uri to gemspec

### DIFF
--- a/loofah.gemspec
+++ b/loofah.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
     "bug_tracker_uri" => "#{spec.homepage}/issues",
     "changelog_uri" => "#{spec.homepage}/blob/main/CHANGELOG.md",
     "documentation_uri" => "https://www.rubydoc.info/gems/loofah/",
+    "funding_uri" => "https://github.com/sponsors/flavorjones",
   }
 
   spec.require_paths = ["lib"]


### PR DESCRIPTION
I noticed that the project already has a FUNDING.yml. This PR adds the `funding_uri` to your gemspec to help increase visibility using the `bundle fund` command in Bundler.