### PR TITLE
ci: add ruby 3.4, drop jruby-head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "head", "truffleruby-head", "jruby-9.4", "jruby-head"]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "head", "truffleruby-head", "jruby-9.4"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
because jruby-head continues to have the jar-dependencies problem