### PR TITLE
Unpin jar-dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ group :development do
   gem("minitest", ["~> 5.14"])
   gem("rake", ["~> 13.0"])
   gem("rdoc", [">= 4.0", "< 7"])
-  gem("jar-dependencies", "0.4.1") if RUBY_PLATFORM == "java" # https://github.com/jruby/jruby/issues/7262
 
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.0.0")
     gem("rubocop", "1.65.0")


### PR DESCRIPTION
Hopefully this clears up build issues. The recent release of jar-dependencies 0.5.3 ships with JRuby, and loading 0.4.1 may be conflicting.