### PR TITLE
Remove `feed` from the default allowed protocols

### DIFF
--- a/lib/loofah/html5/safelist.rb
+++ b/lib/loofah/html5/safelist.rb
@@ -987,7 +987,6 @@ module Loofah
         "data",
         "ed2k",
         "fax",
-        "feed",
         "ftp",
         "gopher",
         "http",

--- a/test/html5/test_sanitizer.rb
+++ b/test/html5/test_sanitizer.rb
@@ -227,6 +227,16 @@ class Html5TestSanitizer < Loofah::TestCase
     end
   end
 
+  def test_should_disallow_feed_uris
+    input = %(<a href="feed:https://example.com/rss.xml">foo</a>)
+    output = "<a>foo</a>"
+    check_sanitization(input, output)
+
+    input = %(<a href="feed:javascript:alert(1)">foo</a>)
+    output = "<a>foo</a>"
+    check_sanitization(input, output)
+  end
+
   ["image/gif", "image/jpeg", "image/png", "text/css", "text/plain"].each do |data_uri_type|
     define_method "test_should_allow_data_#{data_uri_type}_uris" do
       input = %(<a href="data:#{data_uri_type}">foo</a>)


### PR DESCRIPTION
**What problem is this PR intended to solve?**

Loofah's default safelist allows the `feed:` URI scheme. The [feed URI scheme](https://en.wikipedia.org/wiki/Feed_URI_scheme) was never accepted as a standard protocol, and no major browser supports it. Keeping it in the default allowlist creates a potential protocol smuggling vector in non-browser contexts such as webviews and email clients, where legacy handlers may process a URI nested after the scheme.

This PR removes `feed` from `ACCEPTABLE_PROTOCOLS` and adds a test asserting that `feed:` URIs are scrubbed.

Applications that rely on `feed:` links can restore the previous behavior by adding the scheme back to the safelist:

```ruby
Loofah::HTML5::SafeList::ALLOWED_PROTOCOLS.add("feed")
```

Please note that this change hardens Loofah, but there is no known exploit that uses `feed:` and so it does not reach the threshold for a security advisory.

Thanks to hackerone researcher [mk_security](https://hackerone.com/mk_security) for raising this issue in a responsible manner.