### PR TITLE
Harden `data:` URI mediatype handling in the HTML5 scrubber

### DIFF
--- a/lib/loofah/html5/safelist.rb
+++ b/lib/loofah/html5/safelist.rb
@@ -978,7 +978,7 @@ module Loofah
         "stroke-opacity",
       ])
 
-      PROTOCOL_SEPARATOR = /:|(&#0*58)|(&#x70)|(&#x0*3a)|(%|&#37;)3A/i
+      PROTOCOL_SEPARATOR = /:|(&#0*58)|(&#x0*3a)|(%|&#37;)3A/i
 
       ACCEPTABLE_PROTOCOLS = Set.new([
         "afs",

--- a/lib/loofah/html5/scrub.rb
+++ b/lib/loofah/html5/scrub.rb
@@ -16,6 +16,29 @@ module Loofah
       DATA_ATTRIBUTE_NAME = /\Adata-[\w-]+\z/
       URI_PROTOCOL_REGEX = /\A[a-z][a-z0-9+\-.]*:/ # RFC 3986
 
+      # Matches a valid MIME type "essence" (type "/" subtype, no parameters), used to
+      # decide whether a data: URI mediatype is well-formed; a non-match is not a valid
+      # MIME type, which the data: URL processor treats as text/plain. Specs:
+      #
+      #   https://mimesniff.spec.whatwg.org/#valid-mime-type
+      #   https://mimesniff.spec.whatwg.org/#mime-type-essence
+      #   https://mimesniff.spec.whatwg.org/#http-token-code-point
+      #
+      # The character class below is the HTTP token set (tchar) from RFC 9110 section
+      # 5.6.2, https://www.rfc-editor.org/rfc/rfc9110#name-tokens :
+      #
+      #   tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^"
+      #         / "_" / "`" / "|" / "~" / DIGIT / ALPHA
+      #
+      # ALPHA is written a-z, not a-zA-Z, because allowed_uri? downcases the input first.
+      DATA_URI_MEDIATYPE = %r{
+        \A
+        [a-z0-9!\#$%&'*+\-.^_`|~]+   # type:    1*tchar
+        /                            # "/" is not a tchar, so it is the sole delimiter
+        [a-z0-9!\#$%&'*+\-.^_`|~]+   # subtype: 1*tchar
+        \z
+      }x
+
       class << self
         def allowed_element?(element_name)
           ::Loofah::HTML5::SafeList::ALLOWED_ELEMENTS_WITH_LIBXML2.include?(element_name)
@@ -156,9 +179,7 @@ module Loofah
 
             if protocol == "data"
               # permit only allowed data mediatypes
-              mediatype = uri_string.split(SafeList::PROTOCOL_SEPARATOR)[1]
-              mediatype, _ = mediatype.split(/[;,]/)[0..1] if mediatype
-              return false if mediatype && !SafeList::ALLOWED_URI_DATA_MEDIATYPES.include?(mediatype)
+              return false unless SafeList::ALLOWED_URI_DATA_MEDIATYPES.include?(data_uri_mediatype(uri_string))
             end
           end
           true
@@ -237,6 +258,20 @@ module Loofah
             string.encode!(origenc) if origenc
             string
           end
+        end
+
+        private
+
+        # Returns the mediatype of a data: URI per RFC 2397, or nil when the
+        # required comma is absent. allowed_uri? entity-decodes, downcases, and
+        # strips control characters before calling this. An omitted or malformed
+        # mediatype resolves to "text/plain", matching the WHATWG data: URL processor.
+        def data_uri_mediatype(uri_string)
+          metadata, comma, _data = uri_string.delete_prefix("data:").partition(",")
+          return nil if comma.empty?
+
+          mediatype = metadata.delete_suffix(";base64").split(";", 2).first.to_s.strip
+          mediatype.match?(DATA_URI_MEDIATYPE) ? mediatype : "text/plain"
         end
       end
     end

--- a/lib/loofah/version.rb
+++ b/lib/loofah/version.rb
@@ -2,5 +2,5 @@
 
 module Loofah
   # The version of Loofah you are using
-  VERSION = "2.25.1"
+  VERSION = "2.25.2.beta1"
 end

--- a/test/html5/test_sanitizer.rb
+++ b/test/html5/test_sanitizer.rb
@@ -229,8 +229,8 @@ class Html5TestSanitizer < Loofah::TestCase
 
   ["image/gif", "image/jpeg", "image/png", "text/css", "text/plain"].each do |data_uri_type|
     define_method "test_should_allow_data_#{data_uri_type}_uris" do
-      input = %(<a href="data:#{data_uri_type}">foo</a>)
-      output = "<a href='data:#{data_uri_type}'>foo</a>"
+      input = %(<a href="data:#{data_uri_type},">foo</a>)
+      output = "<a href='data:#{data_uri_type},'>foo</a>"
       check_sanitization(input, output)
 
       input = %(<a href="data:#{data_uri_type};base64,R0lGODlhAQABA">foo</a>)
@@ -239,8 +239,8 @@ class Html5TestSanitizer < Loofah::TestCase
     end
 
     define_method "test_should_allow_uppercase_data_#{data_uri_type}_uris" do
-      input = %(<a href="DATA:#{data_uri_type.upcase}">foo</a>)
-      output = "<a href='DATA:#{data_uri_type.upcase}'>foo</a>"
+      input = %(<a href="DATA:#{data_uri_type.upcase},">foo</a>)
+      output = "<a href='DATA:#{data_uri_type.upcase},'>foo</a>"
       check_sanitization(input, output)
     end
   end
@@ -268,6 +268,30 @@ class Html5TestSanitizer < Loofah::TestCase
     input = %(<svg><use href="data:image/svg+xml;base64,PHN2ZyBpZD0neCcgeG1s"/></svg>)
     output = "<svg><use></use></svg>"
 
+    check_sanitization(input, output)
+  end
+
+  def test_should_allow_data_uris_with_an_omitted_mediatype
+    input = %(<a href="data:,hello">foo</a>)
+    output = "<a href='data:,hello'>foo</a>"
+    check_sanitization(input, output)
+
+    input = %(<a href="data:;base64,aGVsbG8=">foo</a>)
+    output = "<a href='data:;base64,aGVsbG8='>foo</a>"
+    check_sanitization(input, output)
+  end
+
+  def test_should_treat_a_malformed_data_uri_mediatype_as_text_plain
+    input = %(<a href="data::text/html,x">foo</a>)
+    output = "<a href='data::text/html,x'>foo</a>"
+    check_sanitization(input, output)
+
+    input = %(<a href="data:image/png:text/html,x">foo</a>)
+    output = "<a href='data:image/png:text/html,x'>foo</a>"
+    check_sanitization(input, output)
+
+    input = %(<a href="data:&#58text/html,payload">foo</a>)
+    output = "<a href='data::text/html,payload'>foo</a>"
     check_sanitization(input, output)
   end
 

--- a/test/html5/test_scrub.rb
+++ b/test/html5/test_scrub.rb
@@ -192,5 +192,10 @@ class UnitHTML5Scrub < Loofah::TestCase
       refute(Loofah::HTML5::Scrub.allowed_uri?("data:image/svg+xml,<svg onload=alert(1)>"))
       refute(Loofah::HTML5::Scrub.allowed_uri?("data:foo"))
     end
+
+    it "disallows data URIs with a literal &#x70 in the mediatype" do
+      refute(Loofah::HTML5::Scrub.allowed_uri?("data:&#x70text/html,<script>alert(1)</script>"))
+      refute(Loofah::HTML5::Scrub.allowed_uri?("data:image/png&#x70,payload"))
+    end
   end
 end

--- a/test/html5/test_scrub.rb
+++ b/test/html5/test_scrub.rb
@@ -197,5 +197,74 @@ class UnitHTML5Scrub < Loofah::TestCase
       refute(Loofah::HTML5::Scrub.allowed_uri?("data:&#x70text/html,<script>alert(1)</script>"))
       refute(Loofah::HTML5::Scrub.allowed_uri?("data:image/png&#x70,payload"))
     end
+
+    it "treats a data URI with a malformed mediatype as text/plain" do
+      assert(Loofah::HTML5::Scrub.allowed_uri?("data::text/html,<script>alert(1)</script>"))
+      assert(Loofah::HTML5::Scrub.allowed_uri?("data:image/png:text/html,<script>alert(1)</script>"))
+    end
+
+    it "does not treat a partial entity match as a mediatype separator" do
+      refute(Loofah::HTML5::Scrub.allowed_uri?("data:image/png&#x3a0,payload"))
+    end
+
+    it "allows data URIs with an omitted mediatype, which defaults to text/plain" do
+      assert(Loofah::HTML5::Scrub.allowed_uri?("data:,hello"))
+      assert(Loofah::HTML5::Scrub.allowed_uri?("data:;base64,aGVsbG8="))
+      assert(Loofah::HTML5::Scrub.allowed_uri?("data:;charset=utf-8,hello"))
+    end
+
+    it "disallows data URIs with no mediatype and no data" do
+      refute(Loofah::HTML5::Scrub.allowed_uri?("data:"))
+    end
+  end
+
+  describe ".data_uri_mediatype" do
+    it "returns the mediatype of a valid data URI" do
+      assert_equal("image/png", Loofah::HTML5::Scrub.send(:data_uri_mediatype, "data:image/png,x"))
+      assert_equal("text/html", Loofah::HTML5::Scrub.send(:data_uri_mediatype, "data:text/html,x"))
+      assert_equal("image/svg+xml", Loofah::HTML5::Scrub.send(:data_uri_mediatype, "data:image/svg+xml,x"))
+    end
+
+    it "returns the type/subtype without parameters" do
+      assert_equal("text/plain", Loofah::HTML5::Scrub.send(:data_uri_mediatype, "data:text/plain;charset=utf-8,x"))
+    end
+
+    it "ignores the base64 flag" do
+      assert_equal("image/png", Loofah::HTML5::Scrub.send(:data_uri_mediatype, "data:image/png;base64,x"))
+      assert_equal("text/plain", Loofah::HTML5::Scrub.send(:data_uri_mediatype, "data:text/plain;charset=utf-8;base64,x"))
+    end
+
+    it "defaults an omitted mediatype to text/plain" do
+      assert_equal("text/plain", Loofah::HTML5::Scrub.send(:data_uri_mediatype, "data:,x"))
+      assert_equal("text/plain", Loofah::HTML5::Scrub.send(:data_uri_mediatype, "data:;base64,x"))
+      assert_equal("text/plain", Loofah::HTML5::Scrub.send(:data_uri_mediatype, "data:;charset=utf-8,x"))
+    end
+
+    it "falls back to text/plain for a malformed mediatype" do
+      assert_equal("text/plain", Loofah::HTML5::Scrub.send(:data_uri_mediatype, "data::text/html,x"))
+      assert_equal("text/plain", Loofah::HTML5::Scrub.send(:data_uri_mediatype, "data:image/png:text/html,x"))
+      assert_equal("text/plain", Loofah::HTML5::Scrub.send(:data_uri_mediatype, "data:foo,x"))
+      assert_equal("text/plain", Loofah::HTML5::Scrub.send(:data_uri_mediatype, "data:image/,x"))
+      assert_equal("text/plain", Loofah::HTML5::Scrub.send(:data_uri_mediatype, "data:/plain,x"))
+    end
+
+    it "does not treat a partial entity match as a separator" do
+      assert_equal("image/png&#x3a0", Loofah::HTML5::Scrub.send(:data_uri_mediatype, "data:image/png&#x3a0,payload"))
+      assert_equal("text/plain", Loofah::HTML5::Scrub.send(:data_uri_mediatype, "data:image/pngΠ,payload"))
+    end
+
+    it "strips whitespace around the mediatype" do
+      assert_equal("text/plain", Loofah::HTML5::Scrub.send(:data_uri_mediatype, "data: text/plain ,x"))
+    end
+
+    it "splits on the first comma" do
+      assert_equal("text/plain", Loofah::HTML5::Scrub.send(:data_uri_mediatype, "data:text/plain,a,b,c"))
+    end
+
+    it "returns nil when the required comma is absent" do
+      assert_nil(Loofah::HTML5::Scrub.send(:data_uri_mediatype, "data:"))
+      assert_nil(Loofah::HTML5::Scrub.send(:data_uri_mediatype, "data:image/png"))
+      assert_nil(Loofah::HTML5::Scrub.send(:data_uri_mediatype, "data:text/plain"))
+    end
   end
 end


### PR DESCRIPTION
Two related hardening changes to the HTML5 scrubber's `data:` URI handling. Neither is a security fix. There was no security boundary in either change, and every input the old code misread is inert in a browser.

## Remove `&#x70` from `PROTOCOL_SEPARATOR`

`PROTOCOL_SEPARATOR` carried an alternative, `&#x70`, that was meant to be a hex-encoded colon but is actually the hex character reference for the letter `p`. The real hex colon is already covered by the `&#x0*3a` alternative, so `&#x70` only ever matched the literal string `&#x70`. This typo has been carried unchanged for 19 years.

## Harden `data:` URI mediatype parsing

`allowed_uri?` was extracting the `data:` mediatype by splitting on `PROTOCOL_SEPARATOR`, which matches a colon. A `data:` mediatype is delimited by commas and semicolons, not colons, so the split read the wrong mediatype on a few malformed inputs.

This replaces that with a private `data_uri_mediatype` helper that follows the [WHATWG `data:` URL processor](https://fetch.spec.whatwg.org/#data-urls). It takes the metadata before the first comma, drops a trailing `;base64`, and reads the type and subtype before the first `;`. An omitted or malformed mediatype resolves to `text/plain`, and a URI without the comma that [RFC 2397](https://www.rfc-editor.org/rfc/rfc2397) requires is rejected. The MIME type validity check uses the HTTP token grammar (`tchar`) from [RFC 9110 section 5.6.2](https://www.rfc-editor.org/rfc/rfc9110#name-tokens).

The new parser has full unit coverage, including omitted mediatypes, the `;base64` flag, malformed mediatypes that fall back to `text/plain`, and the entity partial-match edge case.
