### PR TITLE
test: opt into JSON comment parsing for sanitizer testdata

### DIFF
--- a/test/html5/test_sanitizer.rb
+++ b/test/html5/test_sanitizer.rb
@@ -376,7 +376,7 @@ class Html5TestSanitizer < Loofah::TestCase
   ##
   require "json"
   Dir[File.join(File.dirname(__FILE__), "..", "assets", "testdata_sanitizer_tests1.dat")].each do |filename|
-    JSON.parse(File.read(filename)).each do |test|
+    JSON.parse(File.read(filename), allow_comments: true).each do |test|
       it "testdata sanitizer #{test["name"]}" do
         test.delete("name")
         input = test.delete("input")


### PR DESCRIPTION
json 2.20.0 deprecated parsing comments without `allow_comments: true`, and `test/assets/testdata_sanitizer_tests1.dat` has them. Pass the option to silence the deprecation warning.

Backward compatible: json before 2.20.0 ignores the unknown option and parses comments by default, so this works across all supported Rubies and the `json ~> 2.2` test dependency.