### PR TITLE
Properly restrict SVG `href`; Update `allowed_uri?` to handle whitespace character references and numeric character references without semicolons

### DIFF
--- a/lib/loofah/html5/safelist.rb
+++ b/lib/loofah/html5/safelist.rb
@@ -605,6 +605,11 @@ module Loofah
         "stroke",
       ])
 
+      SVG_HREF_ATTRIBUTES = Set.new([
+        "xlink:href",
+        "href",
+      ])
+
       SVG_ALLOW_LOCAL_HREF = Set.new([
         "altGlyph",
         "animate",

--- a/lib/loofah/html5/scrub.rb
+++ b/lib/loofah/html5/scrub.rb
@@ -71,7 +71,7 @@ module Loofah
             end
 
             next unless SafeList::SVG_ALLOW_LOCAL_HREF.include?(node.name) &&
-              attr_name == "xlink:href" &&
+              SafeList::SVG_HREF_ATTRIBUTES.include?(attr_name) &&
               attr_node.value =~ /^\s*[^#\s].*/m
 
             attr_node.remove

--- a/lib/loofah/html5/scrub.rb
+++ b/lib/loofah/html5/scrub.rb
@@ -39,6 +39,10 @@ module Loofah
         \z
       }x
 
+      # HTML5 named character references for whitespace that browsers strip from
+      # URIs. CGI.unescapeHTML does not decode these, so they are handled explicitly.
+      WHITESPACE_CHARACTER_REFERENCES = /&(Tab|NewLine);/
+
       class << self
         def allowed_element?(element_name)
           ::Loofah::HTML5::SafeList::ALLOWED_ELEMENTS_WITH_LIBXML2.include?(element_name)
@@ -168,11 +172,15 @@ module Loofah
         # This method can be used to validate URI attribute values without
         # requiring a Nokogiri DOM node.
         def allowed_uri?(uri_string)
-          # Replace control characters both before and after unescaping.
+          # Control characters are stripped both before and after unescaping, since
+          # unescaping can produce them. That strip must precede
+          # WHITESPACE_CHARACTER_REFERENCES: removing a control character can reveal a
+          # named whitespace reference.
           uri_string = CGI.unescapeHTML(uri_string.gsub(CONTROL_CHARACTERS, ""))
-            .gsub(CONTROL_CHARACTERS, "")
-            .gsub("&colon;", ":")
-            .downcase
+          uri_string.gsub!(CONTROL_CHARACTERS, "")
+          uri_string.gsub!(WHITESPACE_CHARACTER_REFERENCES, "")
+          uri_string.gsub!("&colon;", ":")
+          uri_string.downcase!
           if URI_PROTOCOL_REGEX.match?(uri_string)
             protocol = uri_string.split(SafeList::PROTOCOL_SEPARATOR)[0]
             return false unless SafeList::ALLOWED_PROTOCOLS.include?(protocol)

--- a/lib/loofah/html5/scrub.rb
+++ b/lib/loofah/html5/scrub.rb
@@ -14,7 +14,16 @@ module Loofah
       CSS_WHITESPACE = " "
       CSS_PROPERTY_STRING_WITHOUT_EMBEDDED_QUOTES = /\A(["'])?[^"']+\1\z/
       DATA_ATTRIBUTE_NAME = /\Adata-[\w-]+\z/
-      URI_PROTOCOL_REGEX = /\A[a-z][a-z0-9+\-.]*:/ # RFC 3986
+
+      # Decimal (`&#58`) or hexadecimal (`&#x3a`) form, with or without the trailing semicolon that
+      # CGI.unescapeHTML requires but browsers do not.
+      NUMERIC_CHARACTER_REFERENCE = /&#(x[0-9a-f]+|[0-9]+);?/i
+
+      # A scheme (RFC 3986) followed by a protocol separator. The separator must recognize the same
+      # encoded-colon forms as PROTOCOL_SEPARATOR, otherwise a scheme split by an encoded colon (for
+      # example "javascript&#58alert(1)") would not be recognized as having a scheme and would skip
+      # protocol validation.
+      URI_PROTOCOL_REGEX = /\A[a-z][a-z0-9+\-.]*#{SafeList::PROTOCOL_SEPARATOR}/
 
       # Matches a valid MIME type "essence" (type "/" subtype, no parameters), used to
       # decide whether a data: URI mediatype is well-formed; a non-match is not a valid
@@ -168,15 +177,16 @@ module Loofah
           attr_node.value = values.join(" ")
         end
 
-        # Returns true if the given URI string is safe, false otherwise.
-        # This method can be used to validate URI attribute values without
-        # requiring a Nokogiri DOM node.
+        # Returns true if the given URI string is safe, false otherwise. This method can be used to
+        # validate URI attribute values without requiring a Nokogiri DOM node.
         def allowed_uri?(uri_string)
-          # Control characters are stripped both before and after unescaping, since
-          # unescaping can produce them. That strip must precede
-          # WHITESPACE_CHARACTER_REFERENCES: removing a control character can reveal a
-          # named whitespace reference.
-          uri_string = CGI.unescapeHTML(uri_string.gsub(CONTROL_CHARACTERS, ""))
+          # CGI.unescapeHTML decodes numeric references only when they carry a trailing semicolon, so
+          # also decode the semicolon-less ones, which browsers still decode and execute. Normalizing
+          # more aggressively than a browser only rejects more, which is safe. Control characters are
+          # stripped both before and after decoding, since decoding can produce them. That strip must
+          # precede WHITESPACE_CHARACTER_REFERENCES: removing a control character can reveal a named
+          # whitespace reference.
+          uri_string = decode_numeric_character_references(CGI.unescapeHTML(uri_string.gsub(CONTROL_CHARACTERS, "")))
           uri_string.gsub!(CONTROL_CHARACTERS, "")
           uri_string.gsub!(WHITESPACE_CHARACTER_REFERENCES, "")
           uri_string.gsub!("&colon;", ":")
@@ -191,6 +201,26 @@ module Loofah
             end
           end
           true
+        end
+
+        def decode_numeric_character_references(string)
+          string.gsub(NUMERIC_CHARACTER_REFERENCE) do |reference|
+            digits = ::Regexp.last_match(1)
+            hexadecimal = digits.start_with?("x", "X")
+            digits = digits[1..-1] if hexadecimal
+            significant_digits = digits.sub(/\A0+/, "")
+
+            # The largest code point is U+10FFFF: 7 decimal or 6 hexadecimal significant digits.
+            # Anything longer is out of range; skip it without building a large integer from it.
+            next reference if significant_digits.length > (hexadecimal ? 6 : 7)
+
+            codepoint = significant_digits.to_i(hexadecimal ? 16 : 10)
+            begin
+              codepoint.chr(Encoding::UTF_8)
+            rescue RangeError
+              reference
+            end
+          end
         end
 
         def scrub_uri_attribute(attr_node)

--- a/test/assets/testdata_sanitizer_tests1.dat
+++ b/test/assets/testdata_sanitizer_tests1.dat
@@ -372,6 +372,36 @@
   },
 
   {
+    "name": "should_not_fall_for_xss_image_hack_named_tab",
+    "input": "<img src=\"jav&Tab;ascript:alert('XSS');\" />",
+    "libxml": "<img>"
+  },
+
+  {
+    "name": "should_not_fall_for_xss_image_hack_named_newline",
+    "input": "<img src=\"java&NewLine;script:alert('XSS');\" />",
+    "libxml": "<img>"
+  },
+
+  {
+    "name": "should_not_fall_for_xss_image_hack_named_tab_leading",
+    "input": "<img src=\"&Tab;javascript:alert('XSS');\" />",
+    "libxml": "<img>"
+  },
+
+  {
+    "name": "should_not_fall_for_xss_image_hack_named_newline_leading",
+    "input": "<img src=\"&NewLine;javascript:alert('XSS');\" />",
+    "libxml": "<img>"
+  },
+
+  {
+    "name": "should_not_fall_for_xss_image_hack_named_tab_before_colon",
+    "input": "<img src=\"javascript&Tab;:alert('XSS');\" />",
+    "libxml": "<img>"
+  },
+
+  {
     "name": "should_sanitize_half_open_scripts",
     "input": "<img src=\"javascript:alert('XSS')\"",
     "libxml": "<img>",

--- a/test/html5/test_sanitizer.rb
+++ b/test/html5/test_sanitizer.rb
@@ -310,35 +310,38 @@ class Html5TestSanitizer < Loofah::TestCase
 
     tag_name_dc = tag_name.downcase
 
-    define_method "test_#{tag_name}_should_allow_local_href" do
-      input = %(<#{tag_name} xlink:href="#foo"/>)
-      output = "<#{tag_name_dc} xlink:href='#foo'></#{tag_name_dc}>"
-      xhtmloutput = "<#{tag_name} xlink:href='#foo'></#{tag_name}>"
-      check_sanitization(input, output, xhtmloutput, xhtmloutput)
-    end
+    ["xlink:href", "href"].each do |attr_name|
+      define_method "test_#{tag_name}_should_allow_local_#{attr_name}" do
+        input = %(<#{tag_name} #{attr_name}="#foo"/>)
+        output = "<#{tag_name_dc} #{attr_name}='#foo'></#{tag_name_dc}>"
+        xhtmloutput = "<#{tag_name} #{attr_name}='#foo'></#{tag_name}>"
+        check_sanitization(input, output, xhtmloutput)
+      end
 
-    define_method "test_#{tag_name}_should_allow_local_href_with_newline" do
-      input = %(<#{tag_name} xlink:href="\n#foo"/>)
+      define_method "test_#{tag_name}_should_allow_local_#{attr_name}_with_newline" do
+        input = %(<#{tag_name} #{attr_name}="\n#foo"/>)
 
-      check_sanitization(
-        input,
-        "<#{tag_name_dc} xlink:href='\n#foo'></#{tag_name_dc}>",
-        "<#{tag_name_dc} xlink:href='&#10;#foo'></#{tag_name_dc}>", # nekohtml
-      )
-    end
+        check_sanitization(
+          input,
+          "<#{tag_name_dc} #{attr_name}='\n#foo'></#{tag_name_dc}>",
+          "<#{tag_name_dc} #{attr_name}='&#10;#foo'></#{tag_name_dc}>", # nekohtml
+          "<#{tag_name_dc} #{attr_name}='#foo'></#{tag_name_dc}>", # libxml2 serialization drops newline from 'href'
+        )
+      end
 
-    define_method "test_#{tag_name}_should_forbid_nonlocal_href" do
-      input = %(<#{tag_name} xlink:href="http://bad.com/foo"/>)
-      output = "<#{tag_name_dc}></#{tag_name_dc}>"
-      xhtmloutput = "<#{tag_name}></#{tag_name}>"
-      check_sanitization(input, output, xhtmloutput, xhtmloutput)
-    end
+      define_method "test_#{tag_name}_should_forbid_nonlocal_#{attr_name}" do
+        input = %(<#{tag_name} #{attr_name}="http://bad.com/foo"/>)
+        output = "<#{tag_name_dc}></#{tag_name_dc}>"
+        xhtmloutput = "<#{tag_name}></#{tag_name}>"
+        check_sanitization(input, output, xhtmloutput)
+      end
 
-    define_method "test_#{tag_name}_should_forbid_nonlocal_href_with_newline" do
-      input = %(<#{tag_name} xlink:href="\nhttp://bad.com/foo"/>)
-      output = "<#{tag_name_dc}></#{tag_name_dc}>"
-      xhtmloutput = "<#{tag_name}></#{tag_name}>"
-      check_sanitization(input, output, xhtmloutput, xhtmloutput)
+      define_method "test_#{tag_name}_should_forbid_nonlocal_#{attr_name}_with_newline" do
+        input = %(<#{tag_name} #{attr_name}="\nhttp://bad.com/foo"/>)
+        output = "<#{tag_name_dc}></#{tag_name_dc}>"
+        xhtmloutput = "<#{tag_name}></#{tag_name}>"
+        check_sanitization(input, output, xhtmloutput)
+      end
     end
   end
 

--- a/test/html5/test_scrub.rb
+++ b/test/html5/test_scrub.rb
@@ -174,6 +174,45 @@ class UnitHTML5Scrub < Loofah::TestCase
       refute(Loofah::HTML5::Scrub.allowed_uri?("jav&#x09;ascript:alert(1)"))
     end
 
+    it "disallows javascript URIs with named whitespace character references splitting the scheme" do
+      refute(Loofah::HTML5::Scrub.allowed_uri?("java&Tab;script:alert(1)"))
+      refute(Loofah::HTML5::Scrub.allowed_uri?("java&NewLine;script:alert(1)"))
+      refute(Loofah::HTML5::Scrub.allowed_uri?("&Tab;javascript:alert(1)"))
+      refute(Loofah::HTML5::Scrub.allowed_uri?("&NewLine;javascript:alert(1)"))
+    end
+
+    it "disallows javascript URIs with named whitespace character references before the scheme separator" do
+      refute(Loofah::HTML5::Scrub.allowed_uri?("javascript&Tab;:alert(1)"))
+      refute(Loofah::HTML5::Scrub.allowed_uri?("javascript&NewLine;:alert(1)"))
+    end
+
+    it "disallows javascript URIs combining named whitespace and named colon references" do
+      refute(Loofah::HTML5::Scrub.allowed_uri?("java&Tab;script&colon;alert(1)"))
+      refute(Loofah::HTML5::Scrub.allowed_uri?("java&NewLine;script&colon;alert(1)"))
+    end
+
+    it "disallows javascript URIs with double-encoded named whitespace character references" do
+      refute(Loofah::HTML5::Scrub.allowed_uri?("java&amp;Tab;script:alert(1)"))
+      refute(Loofah::HTML5::Scrub.allowed_uri?("java&amp;NewLine;script:alert(1)"))
+    end
+
+    it "disallows javascript URIs where stripping an embedded control character reveals a named whitespace reference" do
+      refute(Loofah::HTML5::Scrub.allowed_uri?("java&Ta&#0;b;script:alert(1)"))
+      refute(Loofah::HTML5::Scrub.allowed_uri?("java&New&#0;Line;script:alert(1)"))
+    end
+
+    it "allows wrong-cased named whitespace references, which browsers do not decode" do
+      assert(Loofah::HTML5::Scrub.allowed_uri?("java&tab;script:alert(1)"))
+      assert(Loofah::HTML5::Scrub.allowed_uri?("java&NEWLINE;script:alert(1)"))
+    end
+
+    it "does not mutate a frozen argument" do
+      frozen_uri = "JAVA&Tab;SCRIPT&colon;alert(1)"
+
+      assert_predicate(frozen_uri, :frozen?)
+      refute(Loofah::HTML5::Scrub.allowed_uri?(frozen_uri))
+    end
+
     it "disallows vbscript URIs" do
       refute(Loofah::HTML5::Scrub.allowed_uri?("vbscript:msgbox(1)"))
     end

--- a/test/html5/test_scrub.rb
+++ b/test/html5/test_scrub.rb
@@ -213,6 +213,50 @@ class UnitHTML5Scrub < Loofah::TestCase
       refute(Loofah::HTML5::Scrub.allowed_uri?(frozen_uri))
     end
 
+    it "disallows javascript URIs whose scheme is separated by a semicolon-less numeric character reference colon" do
+      refute(Loofah::HTML5::Scrub.allowed_uri?("javascript&#58alert(1)"))
+      refute(Loofah::HTML5::Scrub.allowed_uri?("javascript&#058alert(1)"))
+      refute(Loofah::HTML5::Scrub.allowed_uri?("javascript&#x3a(1)"))
+      refute(Loofah::HTML5::Scrub.allowed_uri?("javascript&#x03a(1)"))
+      refute(Loofah::HTML5::Scrub.allowed_uri?("javascript&#X3A(1)"))
+      refute(Loofah::HTML5::Scrub.allowed_uri?("vbscript&#58msgbox(1)"))
+    end
+
+    it "disallows javascript URIs whose numeric character reference colon is padded with leading zeros" do
+      refute(Loofah::HTML5::Scrub.allowed_uri?("javascript&#0000000000000000000058alert(1)"))
+      refute(Loofah::HTML5::Scrub.allowed_uri?("javascript&#x000000000000000003a(1)"))
+      refute(Loofah::HTML5::Scrub.allowed_uri?("java&#00000000000000000009script:alert(1)"))
+    end
+
+    it "disallows javascript URIs whose scheme is split by a semicolon-less numeric character reference whitespace character" do
+      refute(Loofah::HTML5::Scrub.allowed_uri?("java&#9script:alert(1)"))
+      refute(Loofah::HTML5::Scrub.allowed_uri?("java&#09script:alert(1)"))
+      refute(Loofah::HTML5::Scrub.allowed_uri?("java&#10script:alert(1)"))
+      refute(Loofah::HTML5::Scrub.allowed_uri?("java&#13script:alert(1)"))
+      refute(Loofah::HTML5::Scrub.allowed_uri?("java&#x9script:alert(1)"))
+      refute(Loofah::HTML5::Scrub.allowed_uri?("java&#X09script:alert(1)"))
+    end
+
+    it "disallows javascript URIs assembled from multiple numeric character references" do
+      refute(Loofah::HTML5::Scrub.allowed_uri?("jav&#97script&#58alert(1)"))
+      refute(Loofah::HTML5::Scrub.allowed_uri?("javascript&#x3a&#9alert(1)"))
+    end
+
+    it "allows URIs whose numeric character references do not decode to a scheme colon" do
+      assert(Loofah::HTML5::Scrub.allowed_uri?("javascript&#581alert(1)"))
+      assert(Loofah::HTML5::Scrub.allowed_uri?("javascript&#x3aalert(1)"))
+    end
+
+    it "checks the mediatype of data URIs whose scheme is separated by a numeric character reference" do
+      refute(Loofah::HTML5::Scrub.allowed_uri?("data&#58text/html,<script>alert(1)</script>"))
+      assert(Loofah::HTML5::Scrub.allowed_uri?("data&#x3aimage/png;base64,iVBORw0KGgo"))
+    end
+
+    it "checks the mediatype of data URIs whose mediatype is assembled by a numeric character reference" do
+      refute(Loofah::HTML5::Scrub.allowed_uri?("data:text&#x2fhtml,<script>alert(1)</script>"))
+      assert(Loofah::HTML5::Scrub.allowed_uri?("data:image&#x2fpng;base64,iVBORw0KGgo"))
+    end
+
     it "disallows vbscript URIs" do
       refute(Loofah::HTML5::Scrub.allowed_uri?("vbscript:msgbox(1)"))
     end
@@ -240,10 +284,6 @@ class UnitHTML5Scrub < Loofah::TestCase
     it "treats a data URI with a malformed mediatype as text/plain" do
       assert(Loofah::HTML5::Scrub.allowed_uri?("data::text/html,<script>alert(1)</script>"))
       assert(Loofah::HTML5::Scrub.allowed_uri?("data:image/png:text/html,<script>alert(1)</script>"))
-    end
-
-    it "does not treat a partial entity match as a mediatype separator" do
-      refute(Loofah::HTML5::Scrub.allowed_uri?("data:image/png&#x3a0,payload"))
     end
 
     it "allows data URIs with an omitted mediatype, which defaults to text/plain" do


### PR DESCRIPTION
Commits to address these issues:

- https://github.com/flavorjones/loofah/security/advisories/GHSA-9wjq-cp2p-hrgf
- https://github.com/flavorjones/loofah/security/advisories/GHSA-5qhf-9phg-95m2
- https://github.com/flavorjones/loofah/security/advisories/GHSA-8whx-365g-h9vv
