### PR TITLE
Fix double breakpoint fragment traversal

### DIFF
--- a/lib/loofah/scrubbers.rb
+++ b/lib/loofah/scrubbers.rb
@@ -366,32 +366,28 @@ module Loofah
 
       def scrub(node)
         return CONTINUE unless (node.type == Nokogiri::XML::Node::ELEMENT_NODE) && (node.name == "p")
+        return CONTINUE unless node.at_xpath("./br[following-sibling::br]")
 
-        paragraph_with_break_point_nodes = node.xpath("//p[br[following-sibling::br]]")
+        new_paragraph = node.add_previous_sibling("<p>").first
 
-        paragraph_with_break_point_nodes.each do |paragraph_node|
-          new_paragraph = paragraph_node.add_previous_sibling("<p>").first
-
-          paragraph_node.children.each do |child|
-            remove_blank_text_nodes(child)
-          end
-
-          paragraph_node.children.each do |child|
-            # already unlinked
-            next if child.parent.nil?
-
-            if child.name == "br" && child.next_sibling.name == "br"
-              new_paragraph = paragraph_node.add_previous_sibling("<p>").first
-              child.next_sibling.unlink
-              child.unlink
-            else
-              child.parent = new_paragraph
-            end
-          end
-
-          paragraph_node.unlink
+        node.children.each do |child|
+          remove_blank_text_nodes(child)
         end
 
+        node.children.each do |child|
+          # already unlinked
+          next if child.parent.nil?
+
+          if child.name == "br" && child.next_sibling&.name == "br"
+            new_paragraph = node.add_previous_sibling("<p>").first
+            child.next_sibling.unlink
+            child.unlink
+          else
+            child.parent = new_paragraph
+          end
+        end
+
+        node.unlink
         CONTINUE
       end
 

--- a/test/integration/test_scrubbers.rb
+++ b/test/integration/test_scrubbers.rb
@@ -504,6 +504,30 @@ class IntegrationTestScrubbers < Loofah::TestCase
             assert_equal doc, result
           end
         end
+
+        context ":double_breakpoint" do
+          it "replaces double line breaks in fragments" do
+            doc = klass.parse("<div>#{BREAKPOINT_FRAGMENT}</div>")
+            result = doc.scrub!(:double_breakpoint)
+
+            assert_equal BREAKPOINT_RESULT, doc.xpath("./div").inner_html.delete("\n")
+            assert_equal doc, result
+          end
+
+          it "scrubs each fragment paragraph once" do
+            doc = klass.parse("<div><p>a<br><br>b</p><p>c<br><br>d</p></div>")
+            doc.scrub!(:double_breakpoint)
+
+            assert_equal "<p>a</p><p>b</p><p>c</p><p>d</p>", doc.xpath("./div").inner_html.delete("\n")
+          end
+
+          it "preserves a trailing single break" do
+            doc = klass.parse("<div><p>a<br><br>b<br></p></div>")
+            doc.scrub!(:double_breakpoint)
+
+            assert_equal "<p>a</p><p>b<br></p>", doc.xpath("./div").inner_html.delete("\n")
+          end
+        end
       end
 
       context "#text" do


### PR DESCRIPTION
The `:double_breakpoint` scrubber currently runs an absolute `//p` query from each paragraph. That finds no paragraphs for `DocumentFragment`, despite the public fragment example, and it rescans every paragraph for document inputs. It can also call `name` on a missing sibling when a transformed paragraph ends in a single `<br>`.

This makes the scrubber operate on the paragraph already handed to it, skips paragraphs without adjacent breaks, and guards the sibling lookup.

Verification on Ruby 4.0.6 / Nokogiri 1.19.4:
- full suite: 1,317 runs, 4,444 assertions, zero failures/errors
- focused fragment models cover documented splitting, multiple paragraphs, and a trailing single `<br>`
- `git diff --check` passes