### PR TITLE
[LOW] Pin CI actions and restrict token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,15 @@ on:
     branches:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: "3.4"
           bundler-cache: true
@@ -36,8 +39,8 @@ jobs:
         ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "head", "truffleruby-head", "jruby-9.4", "jruby-10.0", "jruby-head"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true
@@ -57,8 +60,8 @@ jobs:
             command: "bundle exec rake test"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: "3.4"
           bundler-cache: true


### PR DESCRIPTION
## Summary

- Grant the CI workflow only read access to repository contents.
- Pin checkout and Ruby setup actions to their currently resolved immutable commits.
- Retain version comments so routine update tooling and reviewers can identify the upstream releases.

## Risk addressed

The workflow currently executes `actions/checkout@v4` and `ruby/setup-ruby@v1`, both movable references, with GitHub's ambient token permission defaults. If one of those references moves unexpectedly or its upstream repository is compromised, changed code would execute in Loofah's CI jobs. Explicit read-only permissions limit the token, while commit pins make action changes deliberate and reviewable.

I classify this as **low urgency supply-chain hardening**. There is no evidence that either action reference is currently compromised.

## Verification

- `actions/checkout@v4` currently resolves to `11d5960a326750d5838078e36cf38b85af677262`; its `action.yml` exists at that commit.
- `ruby/setup-ruby@v1` currently resolves to `95ef2b042f9d7a56d8268cba8559e2842e2ad01b` (`v1.321.0`); its `action.yml` exists at that commit.
- The workflow parses with Ruby's safe YAML loader.
- `rbenv exec bundle exec rake test`: **1,317 runs, 4,444 assertions, 0 failures, 0 errors** on Ruby 4.0.6.
- `git diff --check` passes.

## Limitations

- GitHub-hosted CI has not run on this branch yet.
- Commit pins require intentional updates when new action releases are adopted.

## Breaking changes

None. All current jobs only read repository contents, and action inputs/job behavior are unchanged.
